### PR TITLE
add system/anaconda dirs to build_env.py, filter non-existent dirs

### DIFF
--- a/build_env.py
+++ b/build_env.py
@@ -153,6 +153,7 @@ class Env(object):
       '/usr/local/include',
       '/usr/include',
   ]
+  INCLUDES = [s for s in INCLUDES if s == GENDIR or os.path.isdir(s)]
   INCLUDES = ' '.join(['-I' + s for s in INCLUDES])
   # Python
   INCLUDES += ' ' + _GetPythonIncludes()
@@ -162,6 +163,7 @@ class Env(object):
       '/usr/local/lib',
       '/usr/lib',
   ]
+  LIBDIRS = [s for s in LIBDIRS if os.path.isdir(s)]
   LIBDIRS = ' '.join(['-L' + s for s in LIBDIRS])
   # Python
   LIBDIRS += ' ' + _GetPythonLibDirs()

--- a/build_env.py
+++ b/build_env.py
@@ -38,6 +38,11 @@ def _GetPythonIncludes():
     pass
   return includes
 
+def _GetPythonLibDirs():
+  python_root = _GetSubprocessOutput(['python-config', '--prefix'])
+  lib_dir = os.path.join(python_root, 'lib')
+  return ' -L' + lib_dir
+
 class Env(object):
   """Env is the class that stores all the build variables."""
   # Define the compile binary commands.
@@ -158,6 +163,8 @@ class Env(object):
       '/usr/lib',
   ]
   LIBDIRS = ' '.join(['-L' + s for s in LIBDIRS])
+  # Python
+  LIBDIRS += ' ' + _GetPythonLibDirs()
   # General link flags for binary targets
   LIBS = []
   LIBS = ' '.join(['-l' + s for s in LIBS])

--- a/build_env.py
+++ b/build_env.py
@@ -146,6 +146,7 @@ class Env(object):
       os.path.join(GENDIR, 'third_party'),
       os.path.join(GENDIR, 'third_party/include'),
       '/usr/local/include',
+      '/usr/include',
   ]
   INCLUDES = ' '.join(['-I' + s for s in INCLUDES])
   # Python
@@ -154,6 +155,7 @@ class Env(object):
   # General lib folders.
   LIBDIRS = MPI_LIBDIRS + [
       '/usr/local/lib',
+      '/usr/lib',
   ]
   LIBDIRS = ' '.join(['-L' + s for s in LIBDIRS])
   # General link flags for binary targets


### PR DESCRIPTION
This adds `/usr/{include,lib}` and `$HOME/anaconda/{include,lib}` to the include/lib dir variables of `build_env.py`.  The last commit also filters out non-existent dirs.  (I'm sure there's a better/more general way to get the anaconda include/lib dirs, and there could be a good reason why any of these things weren't done to begin with -- happy to remove any subset of the commits from this PR.)

I think the default install location for gflags (or some other dependency) on Ubuntu was the `/usr/{include,lib}` dirs, and the Anaconda version of OpenCV is more up to date than Ubuntu's (which I could never install caffe or caffe2 with).
