### PR TITLE
allow Tensor with empty dims (a scalar)

### DIFF
--- a/caffe2/core/blob.h
+++ b/caffe2/core/blob.h
@@ -136,7 +136,7 @@ class Tensor {
   // Special case of above: create a tensor of shape 1, and the given value.
   Tensor(const dtype& value, Context* context)
       : data_(nullptr) {
-    Reshape(std::vector<int>(1, 1));
+    Reshape(std::vector<int>());
     context->template Copy<dtype, Context, CPUContext>(
         mutable_data(), &value, 1);
   }
@@ -144,7 +144,6 @@ class Tensor {
   virtual ~Tensor() {}
 
   void Reshape(const vector<int>& dims) {
-    CHECK_GT(dims.size(), 0);
     dims_ = dims;
     ndim_ = dims_.size();
     // Calculate the size.

--- a/caffe2/core/operator.cc
+++ b/caffe2/core/operator.cc
@@ -55,9 +55,6 @@ vector<dtype> OperatorBase::GetRepeatedArgument<dtype>(                        \
     return vector<dtype>();                                                    \
   }                                                                            \
   vector<dtype> values;                                                        \
-  CHECK(arg_map_[name]->fieldname##_size())                                    \
-      << "Argument does not have the right field: expected "                   \
-      << #fieldname;                                                           \
   for (const auto& v : arg_map_[name]->fieldname()) values.push_back(v);       \
   return values;                                                               \
 }

--- a/caffe2/operators/loss_op.h
+++ b/caffe2/operators/loss_op.h
@@ -20,7 +20,7 @@ class AveragedLoss final : public Operator<dtype, DeviceContext> {
     auto& X = Input(0);
     auto* Loss = Output(0);
     auto* dX = Output(1);
-    Loss->Reshape(std::vector<int>{1});
+    Loss->Reshape(std::vector<int>());
     dX->ReshapeLike(X);
     math::Set<dtype, DeviceContext>(
         dX->size(), static_cast<dtype>(1.) / X.size(), dX->mutable_data(),
@@ -47,7 +47,7 @@ class WeightedSumLoss final : public Operator<dtype, DeviceContext> {
     DCHECK_EQ(X.size(), W.size());
     auto* Loss = Output(0);
     auto* dX = Output(1);
-    Loss->Reshape(std::vector<int>{1});
+    Loss->Reshape(std::vector<int>());
     math::Dot<dtype, DeviceContext>(
         X.size(), X.data(), W.data(), Loss->mutable_data(), &device_context_);
     dX->ReshapeLike(X);


### PR DESCRIPTION
This includes just the commit from #6 to allow a Tensor with empty dimensions (a scalar).

> A Tensor with empty dimensions is now allowed and denotes a scalar, as in Caffe(1) -- in my (and I think @longjon's) opinion this is the more semantically correct way to represent scalars than a 1D tensor with dims [1], and what a scalar function (e.g. a loss function) should return. (And this is what, e.g. numpy does: e.g., import numpy; numpy.zeros([]).size == 1)
