### PR TITLE
remove failing repeated arg death test after #7

### DIFF
--- a/caffe2/core/operator_test.cc
+++ b/caffe2/core/operator_test.cc
@@ -93,7 +93,7 @@ TEST(OperatorDeathTest, CannotAccessParameterWithWrongType) {
                "Argument does not have the right field: expected i");
 }
 
-TEST(OperatorDeathTest, CannotAccessRepeatedParameterWithWrongType) {
+TEST(OperatorDeathTest, DISABLED_CannotAccessRepeatedParameterWithWrongType) {
   OperatorDef op_def;
   Workspace ws;
   op_def.set_name("JustTest0");


### PR DESCRIPTION
"Fixes" `CannotAccessRepeatedParameterWithWrongType` test failure caused by #7.  Let me know if you'd prefer something else replace this test rather than just deleting it (but I can't think of what that would be now that the check is gone).
