### PR TITLE
New cudnn ops

### DIFF
--- a/caffe2/operators/dropout_op_cudnn.cc
+++ b/caffe2/operators/dropout_op_cudnn.cc
@@ -1,0 +1,234 @@
+#include "caffe2/core/common_cudnn.h"
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/core/types.h"
+
+namespace caffe2 {
+
+class CuDNNDropoutOp final : public Operator<CUDAContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CUDAContext);
+
+  CuDNNDropoutOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
+        ratio_(OperatorBase::GetSingleArgument<float>("ratio", 0.5)),
+        is_test_(OperatorBase::GetSingleArgument<int>("is_test", 0)) {
+    DCHECK_GE(ratio_, 0);
+    DCHECK_LT(ratio_, 1);
+    CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
+
+    CUDNN_ENFORCE(cudnnCreateDropoutDescriptor(&dropout_desc_));
+    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(), &states_size_in_bytes_));
+  }
+
+  ~CuDNNDropoutOp() {
+    CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(data_desc_));
+    CUDNN_ENFORCE(cudnnDestroyDropoutDescriptor(dropout_desc_));
+  }
+
+  template <typename T, typename M>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+ protected:
+  CuDNNWrapper cudnn_wrapper_;
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnDropoutDescriptor_t dropout_desc_;
+
+  vector<TIndex> cudnn_input_dims_;
+
+  float ratio_;
+  bool is_test_;
+
+  size_t states_size_in_bytes_, reserve_space_size_in_bytes_;
+  // Input: X, Output: Y, mask, states
+};
+
+class CuDNNDropoutGradientOp final : public Operator<CUDAContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CUDAContext);
+  CuDNNDropoutGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
+        ratio_(OperatorBase::GetSingleArgument<float>("ratio", 0.5)),
+        is_test_(OperatorBase::GetSingleArgument<int>("is_test", 0)) {
+    DCHECK_GE(ratio_, 0);
+    DCHECK_LT(ratio_, 1);
+    CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
+
+    CUDNN_ENFORCE(cudnnCreateDropoutDescriptor(&dropout_desc_));
+    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(), &states_size_in_bytes_));
+  }
+
+  ~CuDNNDropoutGradientOp() {
+    CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(data_desc_));
+  }
+
+  template <typename T, typename M>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+ protected:
+  CuDNNWrapper cudnn_wrapper_;
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnDropoutDescriptor_t dropout_desc_;
+
+  vector<TIndex> cudnn_input_dims_;
+
+  float ratio_;
+  bool is_test_;
+
+  size_t states_size_in_bytes_, reserve_space_size_in_bytes_;
+  // Input: dY, states, Output: dX
+};
+
+template <typename T, typename M>
+bool CuDNNDropoutOp::DoRunWithType() {
+  const auto& X = Input(0);
+  auto* Y = Output(0);
+  auto* reserve = Output(1);
+
+  auto size_prod = 1;
+  for (auto dim : X.dims()) {
+    size_prod *= dim;
+  }
+
+  // Reshape tensor descriptors if necessary
+  if (X.dims() != cudnn_input_dims_) {
+    VLOG(1) << "Setting descriptors";
+    cudnn_input_dims_ = X.dims();
+    CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
+          data_desc_,
+          GetCudnnTensorFormat(StorageOrder::NCHW),
+          cudnnTypeWrapper<T>::type,
+          size_prod,
+          1,
+          1,
+          1));
+    // get the reserve space we need
+    CUDNN_ENFORCE(cudnnDropoutGetReserveSpaceSize(
+          data_desc_, &reserve_space_size_in_bytes_));
+    // store both reserve and states in the same tensor
+    vector<int> state_size{(reserve_space_size_in_bytes_ + states_size_in_bytes_ + sizeof(T)) / sizeof(T)};
+    // resize the output
+    reserve->Resize(state_size);
+
+    // make sure that meta is set
+    T *reserve_data = reserve->template mutable_data<T>();
+
+    // set the dropout descriptor
+    CUDNN_ENFORCE(cudnnSetDropoutDescriptor(
+          dropout_desc_,
+          cudnn_wrapper_.inline_cudnn_handle(),
+          ratio_,
+          reserve_data + reserve_space_size_in_bytes_ / sizeof(T),
+          states_size_in_bytes_,
+          0 // seed
+    ));
+
+  }
+
+  // now actually run the computation
+  if (is_test_) {
+    if (Y != &X) {
+      context_.Copy<T, CUDAContext, CUDAContext>(
+          X.size(), X.template data<T>(), Y->template mutable_data<T>());
+    }
+    return true;
+  } else {
+    CUDNN_ENFORCE(cudnnDropoutForward(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          dropout_desc_,
+          data_desc_, X.template data<T>(),
+          data_desc_, Y->template mutable_data<T>(),
+          reserve->raw_mutable_data(),
+          reserve_space_size_in_bytes_));
+  }
+  return true;
+}
+
+bool CuDNNDropoutOp::RunOnDevice() {
+  // dispatch based on contents of tensor(s)
+  const auto& X = Input(0);
+  auto* Y = Output(0);
+  Y->ResizeLike(X);
+
+  if (X.IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (X.IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  }
+  return false;
+}
+
+template <typename T, typename M>
+bool CuDNNDropoutGradientOp::DoRunWithType() {
+  const auto& dY = Input(0);
+  const auto& states = Input(1);
+  auto* dX = Output(0);
+
+  auto size_prod = 1;
+  for (auto dim : dY.dims()) {
+    size_prod *= dim;
+  }
+
+  if (dY.dims() != cudnn_input_dims_) {
+    cudnn_input_dims_ = dY.dims();
+    CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
+          data_desc_,
+          GetCudnnTensorFormat(StorageOrder::NCHW),
+          cudnnTypeWrapper<T>::type,
+          size_prod,
+          1,
+          1,
+          1));
+    // get the reserve space we need
+    CUDNN_ENFORCE(cudnnDropoutGetReserveSpaceSize(
+          data_desc_, &reserve_space_size_in_bytes_));
+
+    // set the dropout descriptor
+    CUDNN_ENFORCE(cudnnSetDropoutDescriptor(
+          dropout_desc_,
+          cudnn_wrapper_.inline_cudnn_handle(),
+          ratio_,
+          const_cast<T*>(states.template data<T>()) + reserve_space_size_in_bytes_ / sizeof(T),
+          states_size_in_bytes_,
+          0 // seed
+    ));
+  }
+
+  // run the computation
+  CUDNN_ENFORCE(cudnnDropoutBackward(
+        cudnn_wrapper_.inline_cudnn_handle(),
+        dropout_desc_,
+        data_desc_, dY.data<T>(),
+        data_desc_, dX->template mutable_data<T>(),
+        const_cast<void*>(states.raw_data()), reserve_space_size_in_bytes_));
+  return true;
+}
+
+bool CuDNNDropoutGradientOp::RunOnDevice()  {
+  // dispatch based on contents of tensor(s)
+  const auto& dY = Input(0);
+  const auto& states = Input(1);
+  auto* dX = Output(0);
+
+  dX->ResizeLike(dY);
+
+  if (dY.IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (dY.IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  }
+  return false;
+}
+
+namespace {
+REGISTER_CUDNN_OPERATOR(Dropout, CuDNNDropoutOp);
+REGISTER_CUDNN_OPERATOR(DropoutGrad, CuDNNDropoutGradientOp);
+}
+
+}; // namespace caffe2

--- a/caffe2/operators/dropout_op_cudnn.cc
+++ b/caffe2/operators/dropout_op_cudnn.cc
@@ -19,7 +19,8 @@ class CuDNNDropoutOp final : public Operator<CUDAContext> {
     CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
 
     CUDNN_ENFORCE(cudnnCreateDropoutDescriptor(&dropout_desc_));
-    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(), &states_size_in_bytes_));
+    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(),
+          reinterpret_cast<size_t*>(&states_size_in_bytes_)));
   }
 
   ~CuDNNDropoutOp() {
@@ -59,7 +60,8 @@ class CuDNNDropoutGradientOp final : public Operator<CUDAContext> {
     CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
 
     CUDNN_ENFORCE(cudnnCreateDropoutDescriptor(&dropout_desc_));
-    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(), &states_size_in_bytes_));
+    CUDNN_ENFORCE(cudnnDropoutGetStatesSize(cudnn_wrapper_.inline_cudnn_handle(),
+          reinterpret_cast<size_t*>(&states_size_in_bytes_)));
   }
 
   ~CuDNNDropoutGradientOp() {
@@ -110,7 +112,7 @@ bool CuDNNDropoutOp::DoRunWithType() {
           1));
     // get the reserve space we need
     CUDNN_ENFORCE(cudnnDropoutGetReserveSpaceSize(
-          data_desc_, &reserve_space_size_in_bytes_));
+          data_desc_, reinterpret_cast<size_t*>(&reserve_space_size_in_bytes_)));
     // store both reserve and states in the same tensor
     vector<int> state_size{(reserve_space_size_in_bytes_ + states_size_in_bytes_ + sizeof(T)) / sizeof(T)};
     // resize the output
@@ -187,7 +189,7 @@ bool CuDNNDropoutGradientOp::DoRunWithType() {
           1));
     // get the reserve space we need
     CUDNN_ENFORCE(cudnnDropoutGetReserveSpaceSize(
-          data_desc_, &reserve_space_size_in_bytes_));
+          data_desc_, reinterpret_cast<size_t*>(&reserve_space_size_in_bytes_)));
 
     // set the dropout descriptor
     CUDNN_ENFORCE(cudnnSetDropoutDescriptor(

--- a/caffe2/operators/dropout_op_cudnn.cc
+++ b/caffe2/operators/dropout_op_cudnn.cc
@@ -127,7 +127,7 @@ bool CuDNNDropoutOp::DoRunWithType() {
           dropout_desc_,
           cudnn_wrapper_.inline_cudnn_handle(),
           ratio_,
-          reserve_data + reserve_space_size_in_bytes_ / elem_size;
+          reserve_data + reserve_space_size_in_bytes_ / elem_size,
           states_size_in_bytes_,
           0 // seed
     ));

--- a/caffe2/operators/dropout_op_cudnn.cc
+++ b/caffe2/operators/dropout_op_cudnn.cc
@@ -42,7 +42,7 @@ class CuDNNDropoutOp final : public Operator<CUDAContext> {
   float ratio_;
   bool is_test_;
 
-  size_t states_size_in_bytes_, reserve_space_size_in_bytes_;
+  int states_size_in_bytes_, reserve_space_size_in_bytes_;
   // Input: X, Output: Y, mask, states
 };
 
@@ -81,7 +81,7 @@ class CuDNNDropoutGradientOp final : public Operator<CUDAContext> {
   float ratio_;
   bool is_test_;
 
-  size_t states_size_in_bytes_, reserve_space_size_in_bytes_;
+  int states_size_in_bytes_, reserve_space_size_in_bytes_;
   // Input: dY, states, Output: dX
 };
 

--- a/caffe2/operators/local_response_normalization_op_cudnn.cc
+++ b/caffe2/operators/local_response_normalization_op_cudnn.cc
@@ -1,0 +1,209 @@
+#include "caffe2/core/common_cudnn.h"
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/core/types.h"
+
+namespace caffe2 {
+
+class CuDNNLRNOp final : public Operator<CUDAContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CUDAContext);
+
+  CuDNNLRNOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
+        size_(OperatorBase::GetSingleArgument<int>("size", 0)),
+        alpha_(OperatorBase::GetSingleArgument<float>("alpha", 0)),
+        beta_(OperatorBase::GetSingleArgument<float>("beta", 0)),
+        bias_(OperatorBase::GetSingleArgument<float>("bias", 1)) {
+    CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
+
+    CUDNN_ENFORCE(cudnnCreateLRNDescriptor(&norm_desc_));
+    CUDNN_ENFORCE(cudnnSetLRNDescriptor(norm_desc_, size_, alpha_, beta_, bias_));
+  }
+
+  ~CuDNNLRNOp() {
+    CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(data_desc_));
+    CUDNN_ENFORCE(cudnnDestroyLRNDescriptor(norm_desc_));
+  }
+
+  template <typename T, typename M>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+ protected:
+  CuDNNWrapper cudnn_wrapper_;
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnLRNDescriptor_t norm_desc_;
+
+  vector<TIndex> cudnn_input_dims_;
+
+  const int size_;
+  const float alpha_;
+  const float beta_;
+  const float bias_;
+
+  // Input: X, Output: Y
+};
+
+class CuDNNLRNGradientOp final : public Operator<CUDAContext> {
+ public:
+  USE_OPERATOR_FUNCTIONS(CUDAContext);
+  CuDNNLRNGradientOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<CUDAContext>(operator_def, ws),
+        cudnn_wrapper_(&context_),
+        size_(OperatorBase::GetSingleArgument<int>("size", 0)),
+        alpha_(OperatorBase::GetSingleArgument<float>("alpha", 0)),
+        beta_(OperatorBase::GetSingleArgument<float>("beta", 0)),
+        bias_(OperatorBase::GetSingleArgument<float>("bias", 1)) {
+    CUDNN_ENFORCE(cudnnCreateTensorDescriptor(&data_desc_));
+
+    CUDNN_ENFORCE(cudnnCreateLRNDescriptor(&norm_desc_));
+    CUDNN_ENFORCE(cudnnSetLRNDescriptor(norm_desc_, size_, alpha_, beta_, bias_));
+  }
+
+  ~CuDNNLRNGradientOp() {
+    CUDNN_ENFORCE(cudnnDestroyTensorDescriptor(data_desc_));
+    CUDNN_ENFORCE(cudnnDestroyLRNDescriptor(norm_desc_));
+  }
+
+  template <typename T, typename M>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+ protected:
+  CuDNNWrapper cudnn_wrapper_;
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnLRNDescriptor_t norm_desc_;
+
+  vector<TIndex> cudnn_input_dims_;
+
+  const int size_;
+  const float alpha_;
+  const float beta_;
+  const float bias_;
+
+  // Input: X, Y, dY
+  // Output: dX
+};
+
+template <typename T, typename M>
+bool CuDNNLRNOp::DoRunWithType() {
+  const auto& X = Input(0);
+  auto* Y = Output(0);
+
+  // Reshape tensor descriptors if necessary
+  if (X.dims() != cudnn_input_dims_) {
+    VLOG(1) << "Setting descriptors";
+    cudnn_input_dims_ = X.dims();
+    int C = 1, H = 1, W = 1;
+    // Normal 4-dimensional tensors for images.
+    C = X.dim32(1);
+    H = X.dim32(2);
+    W = X.dim32(3);
+    CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
+        data_desc_,
+        GetCudnnTensorFormat(StorageOrder::NCHW),
+        cudnnTypeWrapper<T>::type,
+        X.dim32(0),
+        C,
+        H,
+        W));
+  }
+
+  // now actually run the computation
+  CUDNN_ENFORCE(cudnnLRNCrossChannelForward(
+        cudnn_wrapper_.inline_cudnn_handle(),
+        norm_desc_,
+        CUDNN_LRN_CROSS_CHANNEL_DIM1,
+        cudnnTypeWrapper<T>::kOne(),
+        data_desc_, X.template data<T>(),
+        cudnnTypeWrapper<T>::kZero(),
+        data_desc_, Y->template mutable_data<T>()));
+
+  return true;
+}
+
+bool CuDNNLRNOp::RunOnDevice() {
+  // dispatch based on contents of tensor(s)
+  const auto& X = Input(0);
+  auto* Y = Output(0);
+  Y->ResizeLike(X);
+
+  if (X.IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (X.IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  } else {
+    CAFFE_THROW("Unsupported input type");
+  }
+  return false;
+}
+
+template <typename T, typename M>
+bool CuDNNLRNGradientOp::DoRunWithType() {
+  const auto& X = Input(0);
+  const auto& Y = Input(1);
+  const auto& dY = Input(2);
+  auto* dX = Output(0);
+
+  if (dY.dims() != cudnn_input_dims_) {
+    VLOG(1) << "Setting descriptors";
+    cudnn_input_dims_ = dY.dims();
+    int C = 1, H = 1, W = 1;
+    // Normal 4-dimensional tensors for images.
+    C = dY.dim32(1);
+    H = dY.dim32(2);
+    W = dY.dim32(3);
+    CUDNN_ENFORCE(cudnnSetTensor4dDescriptor(
+        data_desc_,
+        GetCudnnTensorFormat(StorageOrder::NCHW),
+        cudnnTypeWrapper<T>::type,
+        dY.dim32(0),
+        C,
+        H,
+        W));
+  }
+
+  // run the computation
+  CUDNN_ENFORCE(cudnnLRNCrossChannelBackward(
+        cudnn_wrapper_.inline_cudnn_handle(),
+        norm_desc_,
+        CUDNN_LRN_CROSS_CHANNEL_DIM1,
+        cudnnTypeWrapper<T>::kOne(),
+        data_desc_, Y.template data<T>(),
+        data_desc_, dY.template data<T>(),
+        data_desc_, X.template data<T>(),
+        cudnnTypeWrapper<T>::kZero(),
+        data_desc_, dX->template mutable_data<T>()));
+  return true;
+}
+
+bool CuDNNLRNGradientOp::RunOnDevice()  {
+  // dispatch based on contents of tensor(s)
+  const auto& X = Input(0);
+  const auto& Y = Input(1);
+  const auto& dY = Input(2);
+  auto* dX = Output(0);
+
+  dX->ResizeLike(dY);
+
+  if (dY.IsType<float>()) {
+    return DoRunWithType<float,float>();
+  } else if (dY.IsType<float16>()) {
+    return DoRunWithType<float16,float>();
+  } else {
+    CAFFE_THROW("Unsupported input type");
+  }
+
+  return false;
+}
+
+namespace {
+REGISTER_CUDNN_OPERATOR(LRN, CuDNNLRNOp);
+REGISTER_CUDNN_OPERATOR(LRNGradient, CuDNNLRNGradientOp);
+}
+
+}; // namespace caffe2

--- a/caffe2/operators/max_pool_with_index.cu
+++ b/caffe2/operators/max_pool_with_index.cu
@@ -107,6 +107,8 @@ bool MaxPoolWithIndexOp::DoRunWithType() {
 bool MaxPoolWithIndexOp::RunOnDevice() {
   auto& X = Input(0);
 
+  CAFFE_ENFORCE(X.ndim() == 4, "Operator only supports 4D tensors");
+
   if (X.IsType<float>()) {
     return DoRunWithType<float>();
   } else if (X.IsType<float16>()) {
@@ -123,6 +125,8 @@ bool MaxPoolWithIndexGradientOp::DoRunWithType() {
   auto& dY = Input(1);
   auto& mask = Input(2);
   auto* dX = Output(0);
+
+  CAFFE_ENFORCE(X.ndim() == 4, "Operator only supports 4D tensors");
 
   dX->ResizeLike(X);
   ConvPoolOpBase<CUDAContext>::ComputePads(vector<int>{X.dim32(2), X.dim32(3)});

--- a/caffe2/operators/max_pool_with_index.cu
+++ b/caffe2/operators/max_pool_with_index.cu
@@ -1,0 +1,197 @@
+#include "caffe2/operators/max_pool_with_index.h"
+#include "caffe2/utils/conversions.h"
+
+namespace caffe2 {
+
+namespace {
+
+/***
+  * Note: CUDA kernels are minor changes from those at:
+  * https://github.com/BVLC/caffe/blob/master/src/caffe/layers/pooling_layer.cu
+  * Originally licensed under BSD
+  **/
+template <typename Dtype>
+__global__ void MaxPoolForward(const int nthreads,
+    const Dtype* const bottom_data, const int num, const int channels,
+    const int height, const int width, const int pooled_height,
+    const int pooled_width, const int kernel_h, const int kernel_w,
+    const int stride_h, const int stride_w, const int pad_h, const int pad_w,
+    Dtype* const top_data, int* mask) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    const int pw = index % pooled_width;
+    const int ph = (index / pooled_width) % pooled_height;
+    const int c = (index / pooled_width / pooled_height) % channels;
+    const int n = index / pooled_width / pooled_height / channels;
+    int hstart = ph * stride_h - pad_h;
+    int wstart = pw * stride_w - pad_w;
+    const int hend = min(hstart + kernel_h, height);
+    const int wend = min(wstart + kernel_w, width);
+    hstart = max(hstart, 0);
+    wstart = max(wstart, 0);
+    float maxval = -FLT_MAX;
+    int maxidx = -1;
+    const Dtype* const bottom_slice =
+        bottom_data + (n * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        if (convert::To<Dtype,float>(bottom_slice[h * width + w]) > maxval) {
+          maxidx = h * width + w;
+          maxval = convert::To<Dtype, float>(bottom_slice[maxidx]);
+        }
+      }
+    }
+    top_data[index] = convert::To<float, Dtype>(maxval);
+    mask[index] = maxidx;
+  }
+}
+
+template <typename Dtype>
+__global__ void MaxPoolBackward(const int nthreads, const Dtype* const top_diff,
+    const int* const mask, const int num,
+    const int channels, const int height, const int width,
+    const int pooled_height, const int pooled_width, const int kernel_h,
+    const int kernel_w, const int stride_h, const int stride_w, const int pad_h,
+    const int pad_w, Dtype* const bottom_diff) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    // find out the local index
+    // find out the local offset
+    const int w = index % width;
+    const int h = (index / width) % height;
+    const int c = (index / width / height) % channels;
+    const int n = index / width / height / channels;
+    const int phstart =
+         (h + pad_h < kernel_h) ? 0 : (h + pad_h - kernel_h) / stride_h + 1;
+    const int phend = min((h + pad_h) / stride_h + 1, pooled_height);
+    const int pwstart =
+         (w + pad_w < kernel_w) ? 0 : (w + pad_w - kernel_w) / stride_w + 1;
+    const int pwend = min((w + pad_w) / stride_w + 1, pooled_width);
+    float gradient = 0;
+    const int offset = (n * channels + c) * pooled_height * pooled_width;
+    const Dtype* const top_diff_slice = top_diff + offset;
+    const int* const mask_slice = mask + offset;
+
+    for (int ph = phstart; ph < phend; ++ph) {
+      for (int pw = pwstart; pw < pwend; ++pw) {
+        if (mask_slice[ph * pooled_width + pw] == h * width + w) {
+          gradient += convert::To<Dtype, float>(top_diff_slice[ph * pooled_width + pw]);
+        }
+      }
+    }
+    bottom_diff[index] = convert::To<float, Dtype>(gradient);
+  }
+}
+};
+
+
+template <typename T>
+bool MaxPoolWithIndexOp::DoRunWithType() {
+	auto& X = Input(0);
+  auto* Y = Output(0);
+  auto* mask = Output(1);
+
+  ConvPoolOpBase<CUDAContext>::SetOutputSize(X, Y, X.dim32(1));
+  int output_size = Y->size();
+  mask->Resize(output_size);
+
+  MaxPoolForward<T><<<CAFFE_GET_BLOCKS(output_size),
+                      CAFFE_CUDA_NUM_THREADS,
+                      0,
+                      context_.cuda_stream()>>>(
+      output_size, X.data<T>(), X.dim32(0), X.dim32(1), X.dim32(2), X.dim32(3),
+      Y->dim32(2), Y->dim32(3), kernel_h(), kernel_w(), stride_h(), stride_w(),
+      pad_t(), pad_l(), Y->mutable_data<T>(), mask->mutable_data<int>());
+  return true;
+
+}
+
+bool MaxPoolWithIndexOp::RunOnDevice() {
+  auto& X = Input(0);
+
+  if (X.IsType<float>()) {
+    return DoRunWithType<float>();
+  } else if (X.IsType<float16>()) {
+    return DoRunWithType<float16>();
+  } else {
+    CAFFE_THROW("Unsupported input type");
+  }
+  return false;
+}
+
+template <typename T>
+bool MaxPoolWithIndexGradientOp::DoRunWithType() {
+  auto& X  = Input(0);
+  auto& dY = Input(1);
+  auto& mask = Input(2);
+  auto* dX = Output(0);
+
+  dX->ResizeLike(X);
+  ConvPoolOpBase<CUDAContext>::ComputePads(vector<int>{X.dim32(2), X.dim32(3)});
+
+  MaxPoolBackward<T><<<CAFFE_GET_BLOCKS(X.size()),
+                       CAFFE_CUDA_NUM_THREADS,
+                       0,
+                       context_.cuda_stream()>>>(
+      X.size(), dY.data<T>(), mask.data<int>(), X.dim32(0), X.dim32(1), X.dim32(2), X.dim32(3),
+      dY.dim32(2), dY.dim32(3), kernel_h(), kernel_w(), stride_h(), stride_w(),
+      pad_t(), pad_l(), dX->template mutable_data<T>());
+  return true;
+}
+
+bool MaxPoolWithIndexGradientOp::RunOnDevice() {
+  auto& X = Input(0);
+
+  if (X.IsType<float>()) {
+    return DoRunWithType<float>();
+  } else if (X.IsType<float16>()) {
+    return DoRunWithType<float16>();
+  } else {
+    CAFFE_THROW("Unsupported input type");
+  }
+  return false;
+}
+
+namespace {
+
+REGISTER_CUDA_OPERATOR(MaxPoolWithIndex, MaxPoolWithIndexOp);
+REGISTER_CUDA_OPERATOR(MaxPoolWithIndexGradient, MaxPoolWithIndexGradientOp);
+
+class GetMaxPoolWithIndexGradient : public GradientMakerBase {
+  using GradientMakerBase::GradientMakerBase;
+  vector<OperatorDef> GetGradientDefs() override {
+    return SingleGradientDef(
+        "MaxPoolWithIndexGradient",
+        "",
+        vector<string>{I(0), GO(0), O(1)},
+        vector<string>{GI(0)});
+  }
+};
+
+REGISTER_GRADIENT(MaxPoolWithIndex, GetMaxPoolWithIndexGradient);
+
+OPERATOR_SCHEMA(MaxPoolWithIndex)
+  .NumInputs(1)
+  .NumOutputs(2)
+  .TensorInferenceFunction(ConvPoolOpBase<CPUContext>::TensorInferenceForPool)
+  .SetDoc(R"DOC(
+MaxPoolWithIndex consumes an input blob X and applies max pooling across the
+blob according to kernel sizes, stride sizes and pad lengths defined by the
+ConvPoolOpBase operator. It also produces an explicit mask that defines the
+location that all maximum values were found, which is re-used in the gradient
+pass. This op is deterministic.
+  )DOC")
+  .Input(0, "X", "Input data tensor from the previous operator; dimensions "
+  "depend on whether the NCHW or NHWC operators are being used. For example, "
+  "in the former, the input has size (N x C x H x W), where N is the batch "
+  "size, C is the number of channels, and H and W are the height and the width "
+  "of the data. The corresponding permutation of dimensions is used in the "
+  "latter case. ")
+  .Output(0, "Y", "Output data tensor from average pooling across the input "
+  "tensor. Dimensions will vary based on various kernel, stride, and pad "
+  "sizes.")
+  .Output(1, "Index", "Mask of location indices of the found maximum values, "
+  " used in the gradient operator to accumulate dY values to the appropriate "
+  "locations in Y");
+
+};
+
+}; // namespace caffe2

--- a/caffe2/operators/max_pool_with_index.h
+++ b/caffe2/operators/max_pool_with_index.h
@@ -1,0 +1,48 @@
+#include <cfloat>
+#include "caffe2/core/context.h"
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/operators/pool_op.h"
+#include "caffe2/operators/conv_pool_op_base.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+class MaxPoolWithIndexOp final : public ConvPoolOpBase<CUDAContext> {
+ public:
+  USE_CONV_POOL_BASE_FUNCTIONS(CUDAContext);
+  MaxPoolWithIndexOp(const OperatorDef& operator_def, Workspace* ws)
+    : ConvPoolOpBase<CUDAContext>(operator_def, ws) {
+  }
+  ~MaxPoolWithIndexOp() {
+  }
+
+  template <typename T>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+  // Input: X
+  // Output: Y, mask
+};
+
+class MaxPoolWithIndexGradientOp final : public ConvPoolOpBase<CUDAContext> {
+ public:
+  USE_CONV_POOL_BASE_FUNCTIONS(CUDAContext);
+  MaxPoolWithIndexGradientOp(const OperatorDef& operator_def, Workspace* ws)
+    : ConvPoolOpBase<CUDAContext>(operator_def, ws) {
+  }
+  ~MaxPoolWithIndexGradientOp() {
+  }
+
+  template <typename T>
+  bool DoRunWithType();
+
+  bool RunOnDevice() override;
+
+  // Input: X, dY, mask
+  // Output: dX
+};
+
+}; // namespace caffe2 

--- a/caffe2/python/brew.py
+++ b/caffe2/python/brew.py
@@ -33,6 +33,7 @@ class HelperWrapper(object):
         'dropout': dropout,
         'max_pool': max_pool,
         'average_pool': average_pool,
+        'max_pool_with_index' : max_pool_with_index,
         'lrn': lrn,
         'softmax': softmax,
         'instance_norm': instance_norm,

--- a/caffe2/python/cnn.py
+++ b/caffe2/python/cnn.py
@@ -122,13 +122,10 @@ class CNNModelHelper(ModelHelper):
         return brew.fc_sparse(self, *args, **kwargs)
 
     def Dropout(self, *args, **kwargs):
-        return brew.dropout(self, *args, **kwargs)
+        return brew.dropout(self, *args, order=self.order, use_cudnn=self.use_cudnn, **kwargs)
 
     def LRN(self, *args, **kwargs):
-        return brew.lrn(self, order=self.order, *args, **kwargs)
-
-    def LRN(self, *args, **kwargs):
-        return model_helpers.LRN(self, *args, order=self.order, **kwargs)
+        return brew.lrn(self, *args, order=self.order, use_cudnn=self.use_cudnn, **kwargs)
 
     def Softmax(self, *args, **kwargs):
         return brew.softmax(self, *args, use_cudnn=self.use_cudnn, **kwargs)
@@ -173,7 +170,7 @@ class CNNModelHelper(ModelHelper):
         )
 
     def MaxPoolWithIndex(self, *args, **kwargs):
-        return model_helpers.MaxPoolWithIndex(self, *args, order=self.order, **kwargs)
+        return brew.max_pool_with_index(self, *args, order=self.order, **kwargs)
 
     def AveragePool(self, *args, **kwargs):
         return brew.average_pool(

--- a/caffe2/python/cnn.py
+++ b/caffe2/python/cnn.py
@@ -169,6 +169,9 @@ class CNNModelHelper(ModelHelper):
             self, *args, use_cudnn=self.use_cudnn, order=self.order, **kwargs
         )
 
+    def MaxPoolWithIndex(self, *args, **kwargs):
+        return model_helpers.MaxPoolWithIndex(self, *args, order=self.order, **kwargs)
+
     def AveragePool(self, *args, **kwargs):
         return brew.average_pool(
             self, *args, use_cudnn=self.use_cudnn, order=self.order, **kwargs

--- a/caffe2/python/cnn.py
+++ b/caffe2/python/cnn.py
@@ -127,6 +127,9 @@ class CNNModelHelper(ModelHelper):
     def LRN(self, *args, **kwargs):
         return brew.lrn(self, order=self.order, *args, **kwargs)
 
+    def LRN(self, *args, **kwargs):
+        return model_helpers.LRN(self, *args, order=self.order, **kwargs)
+
     def Softmax(self, *args, **kwargs):
         return brew.softmax(self, *args, use_cudnn=self.use_cudnn, **kwargs)
 

--- a/caffe2/python/helpers/dropout.py
+++ b/caffe2/python/helpers/dropout.py
@@ -6,7 +6,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-def dropout(model, blob_in, blob_out, **kwargs):
+def dropout(model, blob_in, blob_out, use_cudnn=False, **kwargs):
     """dropout"""
+    if use_cudnn:
+        kwargs['engine'] = 'CUDNN'
     return model.net.Dropout(
         blob_in, [blob_out, "_" + blob_out + "_mask"], **kwargs)[0]

--- a/caffe2/python/helpers/normalization.py
+++ b/caffe2/python/helpers/normalization.py
@@ -8,15 +8,24 @@ from __future__ import unicode_literals
 from caffe2.python import core
 
 
-def lrn(model, blob_in, blob_out, order="NCHW", **kwargs):
+def lrn(model, blob_in, blob_out, order="NCHW", use_cudnn=False, **kwargs):
     """LRN"""
-    return model.net.LRN(
+    if use_cudnn:
+        kwargs['engine'] = 'CUDNN'
+        blobs_out = blob_out
+    else:
+        blobs_out = [blob_out, "_" + blob_out + "_scale"]
+    lrn = model.net.LRN(
         blob_in,
-        [blob_out, "_" + blob_out + "_scale"],
+        blobs_out,
         order=order,
         **kwargs
-    )[0]
+    )
 
+    if use_cudnn:
+        return lrn
+    else:
+        return lrn[0]
 
 def softmax(model, blob_in, blob_out=None, use_cudnn=False, **kwargs):
     """Softmax."""

--- a/caffe2/python/helpers/pooling.py
+++ b/caffe2/python/helpers/pooling.py
@@ -26,3 +26,12 @@ def average_pool(model, blob_in, blob_out, use_cudnn=False, order="NCHW",
         order=order,
         **kwargs
     )
+
+def MaxPoolWithIndex(model, blob_in, blob_out, order="NCHW", **kwargs):
+    """Max pooling with an explicit index of max position"""
+    return model.net.MaxPoolWithIndex(
+        blob_in,
+        [blob_out, blob_out+"_index"],
+        order=order,
+        **kwargs
+    )[0]

--- a/caffe2/python/helpers/pooling.py
+++ b/caffe2/python/helpers/pooling.py
@@ -27,7 +27,7 @@ def average_pool(model, blob_in, blob_out, use_cudnn=False, order="NCHW",
         **kwargs
     )
 
-def MaxPoolWithIndex(model, blob_in, blob_out, order="NCHW", **kwargs):
+def max_pool_with_index(model, blob_in, blob_out, order="NCHW", **kwargs):
     """Max pooling with an explicit index of max position"""
     return model.net.MaxPoolWithIndex(
         blob_in,

--- a/caffe2/python/operator_test/pooling_test.py
+++ b/caffe2/python/operator_test/pooling_test.py
@@ -140,6 +140,7 @@ class TestPooling(hu.HypothesisTestCase):
         if method not in ('MaxPool'):
             self.assertGradientChecks(gc, op, [X], 0, [0])
 
+    @unittest.skipIf(not workspace.has_gpu_support, "No GPU support")
     @given(stride=st.integers(1, 3),
            pad=st.integers(0, 3),
            kernel=st.integers(1, 5),

--- a/caffe2/python/operator_test/pooling_test.py
+++ b/caffe2/python/operator_test/pooling_test.py
@@ -35,6 +35,7 @@ class TestPooling(hu.HypothesisTestCase):
                                          method,
                                          gc, dc):
         assume(np.max([pad_t, pad_l, pad_b, pad_r]) < kernel)
+
         op = core.CreateOperator(
             method,
             ["X"],
@@ -138,6 +139,34 @@ class TestPooling(hu.HypothesisTestCase):
         self.assertDeviceChecks(dc, op, [X], [0])
         if method not in ('MaxPool'):
             self.assertGradientChecks(gc, op, [X], 0, [0])
+
+    @given(stride=st.integers(1, 3),
+           pad=st.integers(0, 3),
+           kernel=st.integers(1, 5),
+           size=st.integers(7, 9),
+           input_channels=st.integers(1, 3),
+           batch_size=st.integers(1, 3),
+           **hu.gcs_gpu_only)
+    def test_pooling_with_index(self, stride, pad, kernel, size,
+                     input_channels, batch_size,
+                     gc, dc):
+        assume(pad < kernel)
+        op = core.CreateOperator(
+            "MaxPoolWithIndex",
+            ["X"],
+            ["Y", "Y_index"],
+            stride=stride,
+            kernel=kernel,
+            pad=pad,
+            order="NCHW",
+        )
+        X = np.random.rand(
+            batch_size, size, size, input_channels).astype(np.float32)
+
+        # transpose due to order = NCHW
+        X = X.transpose((0, 3, 1, 2))
+
+        self.assertDeviceChecks(dc, op, [X], [0])
 
     @given(stride=st.integers(1, 3),
            pad=st.integers(0, 3),


### PR DESCRIPTION
cuDNN versions of dropout and LRN (for native fp16 support), port of Caffe's max pooling algo that uses an explicit mask to store locations (also supports fp16 storage)
