### PR TITLE
Fix compiler warning in utils/conversions.h

### DIFF
--- a/caffe2/utils/conversions.h
+++ b/caffe2/utils/conversions.h
@@ -134,7 +134,7 @@ CONVERSIONS_DECL float16 To(const float in) {
 #if __CUDA_ARCH__
   // hacky interface between C2 fp16 and CUDA
   float16 ret;
-  __half r;
+  // __half r;
   // r.x = __float2half_rn(in);
   // ret.x = inf_clip(r).x;
   ret.x = __float2half(in).x;


### PR DESCRIPTION
`/data/caffe2/caffe2/utils/conversions.h(137): warning: variable "r" was declared but never referenced`

Comes from https://github.com/caffe2/caffe2/commit/0fccf7a4f7bb930c884aa70894f087d85e870b0a

/cc @asaadaldien