### PR TITLE
Remove command "touch cmake".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ project(Caffe2 CXX C)
 
 # TODO(bwasti): versioning
 
-# We want CMake to GLOB everything every time.
-execute_process(COMMAND find "${PROJECT_SOURCE_DIR}" -name "CMakeLists.txt" -exec touch {} \;)
-
 # We want to make sure that all submodules are being properly initialized, if
 # one is building from a git checkout.
 find_package(Git)


### PR DESCRIPTION
It is quite normal to rerun cmake to find new files through GLOB commands. This external command always forces cmake to run when you run make, meaning every make command takes longer than necessary. This PR removes the external command `touch CMakeLists.txt` and therefore leaves that decision up to the user when to rerun cmake and speeds up building when cmake is not required to rerun.