### PR TITLE
Update CentOS installation guide.

### DIFF
--- a/_docs/getting-started/centos.md
+++ b/_docs/getting-started/centos.md
@@ -55,15 +55,15 @@ snappy-devel
 gflags and glog is not found in yum for this version of Linux, so install from source:
 
 ```
-git clone https://github.com/gflags/gflags.git
-cd gflags
-mkdir build && cd build
-cmake3 ..
-make -j 8 && sudo make install && cd ../..
-git clone https://github.com/google/glog
-cd glog
-mkdir build && cd build
-cmake3 ..
+git clone https://github.com/gflags/gflags.git && \
+cd gflags && \
+mkdir build && cd build && \
+cmake3 -DCMAKE_CXX_FLAGS='-fPIC' .. && \
+make -j 8 && sudo make install && cd ../.. && \
+git clone https://github.com/google/glog && \
+cd glog && \
+mkdir build && cd build && \
+cmake3 -DCMAKE_CXX_FLAGS='-fPIC' .. && \
 make -j 8 && sudo make install && cd ../..
 ```
 

--- a/_docs/getting-started/centos.md
+++ b/_docs/getting-started/centos.md
@@ -52,14 +52,19 @@ python-pip \
 snappy-devel
 ```
 
-glog is not found in yum for this version of Linux, so install from source:
+gflags and glog is not found in yum for this version of Linux, so install from source:
 
 ```
+git clone https://github.com/gflags/gflags.git
+cd gflags
+mkdir build && cd build
+cmake3 ..
+make -j 8 && sudo make install && cd ../..
 git clone https://github.com/google/glog
 cd glog
-autoreconf -vfi
-./configure
-make && sudo make install && cd ..
+mkdir build && cd build
+cmake3 ..
+make -j 8 && sudo make install && cd ../..
 ```
 
 **Troubleshooting `glog` compilation**


### PR DESCRIPTION
The gflags provided in yum of the current CentOS does not match the dependency requirement of the latest glog version. It also need to be cloned from Github and manually installed from source. Also, the glog need the latest CMake3 to reconfigure.