### PR TITLE
Optional force conv algorithms

### DIFF
--- a/caffe2/operators/conv_op_cudnn.cc
+++ b/caffe2/operators/conv_op_cudnn.cc
@@ -45,7 +45,9 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
             OperatorBase::GetSingleArgument<int>("exhaustive_search", 0)),
         deterministic_(
             OperatorBase::GetSingleArgument<int>("deterministic", 0)),
-        cudnn_state_(OperatorBase::GetSingleArgument<int>("cudnn_state", 0)) {
+        cudnn_state_(OperatorBase::GetSingleArgument<int>("cudnn_state", 0)),
+        force_algo_(OperatorBase::GetRepeatedArgument<int>("force_algo", vector<int>{-1,-1,-1})) {
+    CHECK(!deterministic_ || !exhaustive_search_);
     CAFFE_ENFORCE(group_ > 0);
     CAFFE_ENFORCE(!deterministic_ || !exhaustive_search_);
     OPERATOR_NEEDS_FEATURE(
@@ -138,6 +140,7 @@ class CudnnConvOpBase : public ConvPoolOpBase<CUDAContext> {
   bool exhaustive_search_;
   bool deterministic_;
   size_t cudnn_state_;
+  vector<int> force_algo_; // stored as FWD, dFILTER, dDATA
 };
 
 
@@ -307,7 +310,9 @@ bool CudnnConvOp::DoRunWithType() {
         1,
         CUDNN_CROSS_CORRELATION));
 #endif
-    if (deterministic_) {
+    if (force_algo_[0] >= 0) {
+      algo_ = (cudnnConvolutionFwdAlgo_t)force_algo_[0];
+    } else if (deterministic_) {
       algo_ = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM;
     } else if (exhaustive_search_) {
       algo_ = algo_cache_.getAlgorithm(X.dims(), filter.dims(), [&]() {
@@ -542,8 +547,10 @@ bool CudnnConvGradientOp::DoRunWithType() {
 
     size_t bwd_filter_ws_size, bwd_data_ws_size;
 
-    if (deterministic_) {
-      bwd_data_algo_ = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
+    // Choose dW algorithm
+    if (force_algo_[1] >= 0) {
+      bwd_filter_algo_ = (cudnnConvolutionBwdFilterAlgo_t)force_algo_[1];
+    } else if (deterministic_) {
       bwd_filter_algo_ = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
     } else if (exhaustive_search_) {
       bwd_filter_algo_ =
@@ -583,8 +590,25 @@ bool CudnnConvGradientOp::DoRunWithType() {
             LogCuDNNPerfStats(filter_perf_stat, returned_algo_count);
             return filter_perf_stat[0].algo;
           });
-
-      if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
+    } else {
+      // choose backward algorithm for filter
+      CUDNN_ENFORCE(cudnnGetConvolutionBackwardFilterAlgorithm(
+          cudnn_wrapper_.inline_cudnn_handle(),
+          bottom_desc_,
+          top_desc_,
+          conv_desc_,
+          filter_desc_,
+          CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+          cudnn_ws_nbytes_limit_,
+          &bwd_filter_algo_));
+    }
+    // Pick dX algo if needed
+    if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
+      if (force_algo_[2] >= 0) {
+        bwd_data_algo_ = (cudnnConvolutionBwdDataAlgo_t)force_algo_[2];
+      } else if (deterministic_) {
+        bwd_data_algo_ = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
+      } else if (exhaustive_search_) {
         bwd_data_algo_ =
             data_algo_cache_.getAlgorithm(X.dims(), filter.dims(), [&]() {
               VLOG(1) << "CUDNN Convolution bwd: doing data exhaustive search.";
@@ -621,20 +645,7 @@ bool CudnnConvGradientOp::DoRunWithType() {
               LogCuDNNPerfStats(data_perf_stat, returned_algo_count);
               return data_perf_stat[0].algo;
             });
-      }
-    } else {
-      // choose backward algorithm for filter
-      CUDNN_ENFORCE(cudnnGetConvolutionBackwardFilterAlgorithm(
-          cudnn_wrapper_.inline_cudnn_handle(),
-          bottom_desc_,
-          top_desc_,
-          conv_desc_,
-          filter_desc_,
-          CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-          cudnn_ws_nbytes_limit_,
-          &bwd_filter_algo_));
-      // choose backward algo for data
-      if (OutputSize() == 3 || (no_bias_ && (OutputSize() == 2))) {
+      } else {
         CUDNN_ENFORCE(cudnnGetConvolutionBackwardDataAlgorithm(
             cudnn_wrapper_.inline_cudnn_handle(),
             filter_desc_,
@@ -646,6 +657,7 @@ bool CudnnConvGradientOp::DoRunWithType() {
             &bwd_data_algo_));
       }
     }
+
     // get workspace for backwards filter algorithm
     CUDNN_ENFORCE(cudnnGetConvolutionBackwardFilterWorkspaceSize(
         cudnn_wrapper_.inline_cudnn_handle(),


### PR DESCRIPTION
Allow user to force cuDNN convolution algorithms from python - useful if you're using a standard network and don't want to pay the cost of exhaustive search.

Defined as an array in the order of [fwd, wgrad, dgrad].

Also refactors cudnn_conv_op slightly to split the code to do wgrad and dgrad a little more.