### PR TITLE
Added python-pip and python-numpy into build_raspbian.sh

### DIFF
--- a/scripts/build_raspbian.sh
+++ b/scripts/build_raspbian.sh
@@ -21,6 +21,8 @@ sudo apt-get install \
   libgoogle-glog-dev \
   libprotobuf-dev \
   libpython-dev \
+  python-pip \
+  python-numpy \
   protobuf-compiler \
   python-protobuf
 # python dependencies


### PR DESCRIPTION
Added python-pip and python-numpy into build_raspbian.sh script
because they are not installed in ubuntu/debian minimal image.