### PR TITLE
Allow running predictor without specifying outputs.

### DIFF
--- a/caffe2/core/predictor.cc
+++ b/caffe2/core/predictor.cc
@@ -48,9 +48,11 @@ void Predictor::run(const TensorVector& inputs, TensorVector* outputs) {
 
   CAFFE_ENFORCE(ws_.RunNet(run_net_.name()));
 
-  outputs->resize(run_net_.external_output_size());
-  for (auto i = 0; i < outputs->size(); ++i) {
-    (*outputs)[i] = extractOutputTensor(&ws_, run_net_.external_output(i));
+  if (outputs != nullptr) {
+    outputs->resize(run_net_.external_output_size());
+    for (auto i = 0; i < outputs->size(); ++i) {
+      (*outputs)[i] = extractOutputTensor(&ws_, run_net_.external_output(i));
+    }
   }
 }
 }

--- a/caffe2/core/predictor.h
+++ b/caffe2/core/predictor.h
@@ -24,7 +24,7 @@ class Predictor {
 
   // Postcondition:
   //   outputs->size() == run_net.external_inputs.size()
-  void run(const TensorVector& inputs, TensorVector* outputs);
+  void run(const TensorVector& inputs, TensorVector* outputs = nullptr);
 
   const NetDef& def() const {
     return run_net_;


### PR DESCRIPTION
Sometimes we need result from intermediate layers rather than the external output layers. This can be done by getting blobs from the workspace. By allowing running the predictor without specifying outputs, we do not need to declare the output tensors in advance. We can just simply leave the outputs parameter as null.

While this can also be achieved by removing the redundant layers in the network, in some cases we need both versions in a same program, and this is not flexible.