### PR TITLE
fix TensorProtosDBInput  function for parallel use

### DIFF
--- a/caffe2/python/model_helper.py
+++ b/caffe2/python/model_helper.py
@@ -311,7 +311,7 @@ class ModelHelper(object):
         dbreader_name = "dbreader_" + db
         dbreader = self.param_init_net.CreateDB(
             [], dbreader_name,
-            db=db, db_type=db_type)
+            db=db, db_type=db_type,**kwargs)
         return self.net.TensorProtosDBInput(
             dbreader, blob_out, batch_size=batch_size)
 


### PR DESCRIPTION
I think somebody forget  pass the **kwargs  to self.param_init_net.CreateDB function
it will lead to some name scope error when using multi gpus for parallel training