### PR TITLE
fix #985 compilation error due to type mismatch

### DIFF
--- a/caffe2/operators/top_k_radix_selection.cuh
+++ b/caffe2/operators/top_k_radix_selection.cuh
@@ -356,7 +356,7 @@ __global__ void gatherTopK(const T* inputPtr,
   // Find the start offset for our slice
   const T* inputSliceStart = &inputPtr[slice * inputSliceSize];
   T* topKSliceStart = &topKPtr[slice * outputSliceSize];
-  long* indicesSliceStart = &indicesPtr[slice * outputSliceSize];
+  caffe2::TIndex* indicesSliceStart = &indicesPtr[slice * outputSliceSize];
 
   // Find the k-th highest element in our input
   T topKValue = (T)0;


### PR DESCRIPTION
Fix the error during compilation on Win10+CUDA, not sure if it affects Linux and MacOS.
caffe2/operators/top_k_radix_selection.cuh(359): error : a value of type "caffe2::TIndex *" cannot be used to initialize an entity of type "long *"