### PR TITLE
Add NCCL_VERSION_MIN, use v2 API if installed

### DIFF
--- a/caffe2/contrib/nccl/cuda_nccl_gpu.h
+++ b/caffe2/contrib/nccl/cuda_nccl_gpu.h
@@ -9,6 +9,11 @@
 #include <nccl.h>
 #include <unordered_map>
 
+#define NCCL_VERSION_MIN(major, minor, patch) \
+  ((NCCL_MAJOR > major) || \
+    ((NCCL_MAJOR == major) && ((NCCL_MINOR > minor) || \
+      ((NCCL_MINOR == minor) && (NCCL_PATCH >= patch)) )))
+
 namespace caffe2 {
 
 namespace nccl {


### PR DESCRIPTION
Basic NCCL 2 API support - the same as applied to gloo [here](https://github.com/facebookincubator/gloo/commit/49586d95569f9c093ed053ac2aa71e9dd3857ae4)

/cc @Yangqing @pietern 