### PR TITLE
 fix for caffe to caffe2 translation on SSD and VGG model,

### DIFF
--- a/caffe/proto/caffe.proto
+++ b/caffe/proto/caffe.proto
@@ -403,8 +403,193 @@ message LayerParameter {
   optional ThresholdParameter threshold_param = 128;
   optional TileParameter tile_param = 138;
   optional WindowDataParameter window_data_param = 129;
+  optional NormalizeParameter norm_param = 206;
+  optional PermuteParameter permute_param = 202;
+  optional PriorBoxParameter prior_box_param = 203;
+  optional DetectionOutputParameter detection_output_param = 204;
 }
 
+// Message that stores parameters used by data transformer for resize policy
+message ResizeParameter {
+  //Probability of using this resize policy
+  optional float prob = 1 [default = 1];
+
+  enum Resize_mode {
+    WARP = 1;
+    FIT_SMALL_SIZE = 2;
+    FIT_LARGE_SIZE_AND_PAD = 3;
+  }
+  optional Resize_mode resize_mode = 2 [default = WARP];
+  optional uint32 height = 3 [default = 0];
+  optional uint32 width = 4 [default = 0];
+  // A parameter used to update bbox in FIT_SMALL_SIZE mode.
+  optional uint32 height_scale = 8 [default = 0];
+  optional uint32 width_scale = 9 [default = 0];
+
+  enum Pad_mode {
+    CONSTANT = 1;
+    MIRRORED = 2;
+    REPEAT_NEAREST = 3;
+  }
+  // Padding mode for BE_SMALL_SIZE_AND_PAD mode and object centering
+  optional Pad_mode pad_mode = 5 [default = CONSTANT];
+  // if specified can be repeated once (would fill all the channels)
+  // or can be repeated the same number of times as channels
+  // (would use it them to the corresponding channel)
+  repeated float pad_value = 6;
+
+  enum Interp_mode { //Same as in OpenCV
+    LINEAR = 1;
+    AREA = 2;
+    NEAREST = 3;
+    CUBIC = 4;
+    LANCZOS4 = 5;
+  }
+  //interpolation for for resizing
+  repeated Interp_mode interp_mode = 7;
+}
+
+message SaveOutputParameter {
+  // Output directory. If not empty, we will save the results.
+  optional string output_directory = 1;
+  // Output name prefix.
+  optional string output_name_prefix = 2;
+  // Output format.
+  //    VOC - PASCAL VOC output format.
+  //    COCO - MS COCO output format.
+  optional string output_format = 3;
+  // If you want to output results, must also provide the following two files.
+  // Otherwise, we will ignore saving results.
+  // label map file.
+  optional string label_map_file = 4;
+  // A file which contains a list of names and sizes with same order
+  // of the input DB. The file is in the following format:
+  //    name height width
+  //    ...
+  optional string name_size_file = 5;
+  // Number of test images. It can be less than the lines specified in
+  // name_size_file. For example, when we only want to evaluate on part
+  // of the test images.
+  optional uint32 num_test_image = 6;
+  // The resize parameter used in saving the data.
+  optional ResizeParameter resize_param = 7;
+}
+
+message NonMaximumSuppressionParameter {
+  // Threshold to be used in nms.
+  optional float nms_threshold = 1 [default = 0.3];
+  // Maximum number of results to be kept.
+  optional int32 top_k = 2;
+  // Parameter for adaptive nms.
+  optional float eta = 3 [default = 1.0];
+}
+
+
+// Message that store parameters used by DetectionOutputLayer
+message DetectionOutputParameter {
+  // Number of classes to be predicted. Required!
+  optional uint32 num_classes = 1;
+  // If true, bounding box are shared among different classes.
+  optional bool share_location = 2 [default = true];
+  // Background label id. If there is no background class,
+  // set it as -1.
+  optional int32 background_label_id = 3 [default = 0];
+  // Parameters used for non maximum suppression.
+  optional NonMaximumSuppressionParameter nms_param = 4;
+  // Parameters used for saving detection results.
+  optional SaveOutputParameter save_output_param = 5;
+  // Type of coding method for bbox.
+  optional PriorBoxParameter.CodeType code_type = 6 [default = CORNER];
+  // If true, variance is encoded in target; otherwise we need to adjust the
+  // predicted offset accordingly.
+  optional bool variance_encoded_in_target = 8 [default = false];
+  // Number of total bboxes to be kept per image after nms step.
+  // -1 means keeping all bboxes after nms step.
+  optional int32 keep_top_k = 7 [default = -1];
+  // Only consider detections whose confidences are larger than a threshold.
+  // If not provided, consider all boxes.
+  optional float confidence_threshold = 9;
+  // If true, visualize the detection results.
+  optional bool visualize = 10 [default = false];
+  // The threshold used to visualize the detection results.
+  optional float visualize_threshold = 11;
+  // If provided, save outputs to video file.
+  optional string save_file = 12;
+  // top_k 
+  //optional int32 top_k =13;
+}
+
+// The normalized bounding box [0, 1] w.r.t. the input image size.
+message NormalizedBBox {
+  optional float xmin = 1;
+  optional float ymin = 2;
+  optional float xmax = 3;
+  optional float ymax = 4;
+  optional int32 label = 5;
+  optional bool difficult = 6;
+  optional float score = 7;
+  optional float size = 8;
+}
+
+message PermuteParameter {
+  // The new orders of the axes of data. Notice it should be with
+  // in the same range as the input data, and it starts from 0.
+  // Do not provide repeated order.
+  repeated uint32 order = 1;
+}
+
+// Message that store parameters used by PriorBoxLayer
+message PriorBoxParameter {
+  // Encode/decode type.
+  enum CodeType {
+    CORNER = 1;
+    CENTER_SIZE = 2;
+    CORNER_SIZE = 3;
+  }
+  // Minimum box size (in pixels). Required!
+  repeated float min_size = 1;
+  // Maximum box size (in pixels). Required!
+  repeated float max_size = 2;
+  // Various of aspect ratios. Duplicate ratios will be ignored.
+  // If none is provided, we use default ratio 1.
+  repeated float aspect_ratio = 3;
+  // If true, will flip each aspect ratio.
+  // For example, if there is aspect ratio "r",
+  // we will generate aspect ratio "1.0/r" as well.
+  optional bool flip = 4 [default = true];
+  // If true, will clip the prior so that it is within [0, 1]
+  optional bool clip = 5 [default = false];
+  // Variance for adjusting the prior bboxes.
+  repeated float variance = 6;
+  // By default, we calculate img_height, img_width, step_x, step_y based on
+  // bottom[0] (feat) and bottom[1] (img). Unless these values are explicitely
+  // provided.
+  // Explicitly provide the img_size.
+  optional uint32 img_size = 7;
+  // Either img_size or img_h/img_w should be specified; not both.
+  optional uint32 img_h = 8;
+  optional uint32 img_w = 9;
+
+  // Explicitly provide the step size.
+  optional float step = 10;
+  // Either step or step_h/step_w should be specified; not both.
+  optional float step_h = 11;
+  optional float step_w = 12;
+
+  // Offset to the top left corner of each cell.
+  optional float offset = 13 [default = 0.5];
+}
+
+// Message that stores parameters used by NormalizeLayer
+message NormalizeParameter {
+  optional bool across_spatial = 1 [default = true];
+  // Initial value of scale. Default is 1.0 for all
+  optional FillerParameter scale_filler = 2;
+  // Whether or not scale parameters are shared across channels.
+  optional bool channel_shared = 3 [default = true];
+  // Epsilon for not dividing by zero while normalizing variance
+  optional float eps = 4 [default = 1e-10];
+ }
 // Message that stores parameters used to apply transformation
 // to the data layer's data
 message TransformationParameter {

--- a/caffe2/operators/detection_output_op.cc
+++ b/caffe2/operators/detection_output_op.cc
@@ -1,0 +1,202 @@
+#include "caffe2/operators/detection_output_op.h"
+
+namespace caffe2 {
+
+template <>
+bool DetectionOutputOp<float, CPUContext>::RunOnDevice() {
+	const auto& loc = Input(0);
+	const auto& conf = Input(1); 
+
+  // TODO(ky): 
+  // DetectionOutputOp must run in CUDA devs
+  // because I don't find a way in CPUContext 
+  // to access loc and conf which are in CUDAContext.
+  // So you will get a error when runing in CPU.
+  // Please run in CUDAContext!!!
+  //
+
+
+  //Tensor<CPUContext> loc, conf;
+  //loc.CopyFrom(loc_, &context_);
+  //conf.CopyFrom(conf_, &context_);
+	const auto& prior = OperatorBase::Input<TensorCPU>(2);
+	auto* Y = OperatorBase::Output<TensorCPU>(0);
+
+	const float* loc_data = loc.template data<float>();
+	const float* conf_data = conf.template data<float>();
+	const float* prior_data = prior.template data<float>();
+
+	const int num = loc.dim(0);
+	int num_priors_ = prior.dim(2) / 4;
+	CAFFE_ENFORCE_EQ(num_priors_ * num_loc_classes_ * 4, loc.dim(1));
+	CAFFE_ENFORCE_EQ(num_priors_ * num_classes_, conf.dim(1));
+	
+	// Retrieve all location predictions.
+	vector<LabelBBox> all_loc_preds;
+	GetLocPredictions(loc_data, num, num_priors_, num_loc_classes_,
+										share_location_, &all_loc_preds);
+	
+	// Retrieve all confidences.
+	vector<map<int, vector<float> > > all_conf_scores;
+	GetConfidenceScores(conf_data, num, num_priors_, num_classes_,
+											&all_conf_scores);
+
+	// Retrieve all prior bboxes. It is same within a batch since we assume all
+	// images in a batch are of same dimension.
+	vector<NormalizedBBox> prior_bboxes;
+	vector<vector<float> > prior_variances;
+	GetPriorBBoxes(prior_data, num_priors_, &prior_bboxes, &prior_variances);
+
+	// Decode all loc predictions to bboxes.
+	vector<LabelBBox> all_decode_bboxes;
+	const bool clip_bbox = false;
+	DecodeBBoxesAll(all_loc_preds, prior_bboxes, prior_variances, num,
+									share_location_, num_loc_classes_, background_label_id_,
+									code_type_, variance_encoded_in_target_, clip_bbox,
+									&all_decode_bboxes);
+	
+	int num_kept = 0;
+	vector<map<int, vector<int> > > all_indices;
+	for(int i = 0; i < num; i++) {
+		const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+		const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+		map<int, vector<int> > indices;
+		int num_det = 0;
+		for (int c = 0; c < num_classes_; ++c) {
+			if (c == background_label_id_) {
+				continue;
+			}
+			if (conf_scores.find(c) == conf_scores.end()) {
+				LOG(FATAL) << "Could not find confidence predictions for label " << c;
+			}
+			const vector<float>& scores = conf_scores.find(c)->second;
+			int label = share_location_ ? -1 : c;
+			if (decode_bboxes.find(label) == decode_bboxes.end()) {
+				// Something bad happened if there are no predictions for current label.
+				LOG(FATAL) << "Could not find location predictions for label " << label;
+				continue;
+			}
+			const vector<NormalizedBBox>& bboxes = decode_bboxes.find(label)->second;
+			ApplyNMSFast(bboxes, scores, confidence_threshold_, nms_threshold_, eta_,
+					top_k_, &(indices[c]));
+			num_det += indices[c].size();
+		}
+		if (keep_top_k_ > -1 && num_det > keep_top_k_) {
+			vector<pair<float, pair<int, int> > > score_index_pairs;
+			for (map<int, vector<int> >::iterator it = indices.begin();
+					it != indices.end(); ++it) {
+				int label = it->first;
+				const vector<int>& label_indices = it->second;
+				if (conf_scores.find(label) == conf_scores.end()) {
+					LOG(FATAL) << "Could not find location predictions for " << label;
+					continue;
+				}
+				const vector<float>& scores = conf_scores.find(label)->second;
+				for (int j = 0; j < label_indices.size(); ++j) {
+					int idx = label_indices[j];
+					CAFFE_ENFORCE_LT(idx, scores.size());
+					score_index_pairs.push_back(std::make_pair(
+								scores[idx], std::make_pair(label, idx)));
+				}
+			}
+			// Keep top k results per image.
+			std::sort(score_index_pairs.begin(), score_index_pairs.end(),
+					SortScorePairDescend<pair<int, int> >);
+			score_index_pairs.resize(keep_top_k_);
+			// Store the new indices.
+			map<int, vector<int> > new_indices;
+			for (int j = 0; j < score_index_pairs.size(); ++j) {
+				int label = score_index_pairs[j].second.first;
+				int idx = score_index_pairs[j].second.second;
+				new_indices[label].push_back(idx);
+			}
+			all_indices.push_back(new_indices);
+			num_kept += keep_top_k_;
+		} else {
+			all_indices.push_back(indices);
+			num_kept += num_det;
+		}
+	}
+
+	float* top_data;
+	if(num_kept == 0) {
+		LOG(INFO) << "Couldn't find any detections";
+		Y->Resize(1,1,num,7);
+		top_data = Y->template mutable_data<float>();
+		math::Set<float, CPUContext>(num*7, float(-1), top_data, &context_);
+		// Generate fake results per image.
+		for (int i = 0; i < num; ++i) {
+			top_data[0] = i;
+			top_data += 7;
+		}
+	} else {
+		Y->Resize(1,1,num_kept,7);
+		top_data = Y->template mutable_data<float>();
+	}
+
+	int count = 0;
+	for (int i = 0; i < num; ++i) {
+		const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+		const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+		for (map<int, vector<int> >::iterator it = all_indices[i].begin();
+				it != all_indices[i].end(); ++it) {
+			int label = it->first;
+			if (conf_scores.find(label) == conf_scores.end()) {
+				// Something bad happened if there are no predictions for current label.
+				LOG(FATAL) << "Could not find confidence predictions for " << label;
+				continue;
+			}
+			const vector<float>& scores = conf_scores.find(label)->second;
+			int loc_label = share_location_ ? -1 : label;
+			if (decode_bboxes.find(loc_label) == decode_bboxes.end()) {
+				// Something bad happened if there are no predictions for current label.
+				LOG(FATAL) << "Could not find location predictions for " << loc_label;
+				continue;
+			}
+			const vector<NormalizedBBox>& bboxes =
+				decode_bboxes.find(loc_label)->second;
+			vector<int>& indices = it->second;
+
+			for (int j = 0; j < indices.size(); ++j) {
+				int idx = indices[j];
+				top_data[count * 7] = i;
+				top_data[count * 7 + 1] = label;
+				top_data[count * 7 + 2] = scores[idx];
+				const NormalizedBBox& bbox = bboxes[idx];
+				top_data[count * 7 + 3] = bbox.xmin();
+				top_data[count * 7 + 4] = bbox.ymin();
+				top_data[count * 7 + 5] = bbox.xmax();
+				top_data[count * 7 + 6] = bbox.ymax();
+				++count;
+			}
+		}
+	}
+	
+	return true;
+}
+
+namespace {
+REGISTER_CPU_OPERATOR(DetectionOutput, DetectionOutputOp<float, CPUContext>);
+NO_GRADIENT(DetectionOutput);
+
+OPERATOR_SCHEMA(DetectionOutput)
+	.NumInputs(3)
+	.NumOutputs(1)
+	.SetDoc(R"DOC(DetectionOutputLayer in SSD)DOC")
+	.Arg("num_classes", "num_classes")
+	.Arg("share_location", "share_location")
+	.Arg("background_label_id", "background_label_id")
+	.Arg("nms_threshold", "nms_threshold")
+	.Arg("top_k", "top_k")
+	.Arg("eta", "eta")
+	.Arg("code_type", "code_type")
+	.Arg("variance_encoded_in_target", "variance_encoded_in_target")
+	.Arg("keep_top_k", "keep_top_k")
+	.Arg("confidence_threshold", "confidence_threshold")
+	.Input(0, "loc", "loc")
+	.Input(1, "conf", "conf")
+	.Input(2, "prior", "prior")
+	.Output(0, "Y", "detection results");
+} // namespace 
+
+} // namespace caffe2

--- a/caffe2/operators/detection_output_op.cu
+++ b/caffe2/operators/detection_output_op.cu
@@ -1,0 +1,311 @@
+#include "caffe2/core/context_gpu.h"
+#include "caffe2/operators/detection_output_op.h"
+
+namespace caffe2 {
+
+template <typename Dtype>
+__global__ void DecodeBBoxesKernel(const int nthreads,
+          const Dtype* loc_data, const Dtype* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          const bool clip_bbox, Dtype* bbox_data) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    const int i = index % 4;
+    const int c = (index / 4) % num_loc_classes;
+    const int d = (index / 4 / num_loc_classes) % num_priors;
+    if (!share_location && c == background_label_id) {
+      // Ignore background class if not share_location.
+      return;
+    }
+    const int pi = d * 4;
+    const int vi = pi + num_priors * 4;
+    if (code_type == caffe::PriorBoxParameter_CodeType_CORNER) {
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to add the offset
+        // predictions.
+        bbox_data[index] = prior_data[pi + i] + loc_data[index];
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        bbox_data[index] =
+          prior_data[pi + i] + loc_data[index] * prior_data[vi + i];
+      }
+    } else if (code_type == caffe::PriorBoxParameter_CodeType_CENTER_SIZE) {
+      const Dtype p_xmin = prior_data[pi];
+      const Dtype p_ymin = prior_data[pi + 1];
+      const Dtype p_xmax = prior_data[pi + 2];
+      const Dtype p_ymax = prior_data[pi + 3];
+      const Dtype prior_width = p_xmax - p_xmin;
+      const Dtype prior_height = p_ymax - p_ymin;
+      const Dtype prior_center_x = (p_xmin + p_xmax) / 2.;
+      const Dtype prior_center_y = (p_ymin + p_ymax) / 2.;
+
+      const Dtype xmin = loc_data[index - i];
+      const Dtype ymin = loc_data[index - i + 1];
+      const Dtype xmax = loc_data[index - i + 2];
+      const Dtype ymax = loc_data[index - i + 3];
+
+      Dtype decode_bbox_center_x, decode_bbox_center_y;
+      Dtype decode_bbox_width, decode_bbox_height;
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to retore the offset
+        // predictions.
+        decode_bbox_center_x = xmin * prior_width + prior_center_x;
+        decode_bbox_center_y = ymin * prior_height + prior_center_y;
+        decode_bbox_width = exp(xmax) * prior_width;
+        decode_bbox_height = exp(ymax) * prior_height;
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        decode_bbox_center_x =
+          prior_data[vi] * xmin * prior_width + prior_center_x;
+        decode_bbox_center_y =
+          prior_data[vi + 1] * ymin * prior_height + prior_center_y;
+        decode_bbox_width =
+          exp(prior_data[vi + 2] * xmax) * prior_width;
+        decode_bbox_height =
+          exp(prior_data[vi + 3] * ymax) * prior_height;
+      }
+
+      switch (i) {
+        case 0:
+          bbox_data[index] = decode_bbox_center_x - decode_bbox_width / 2.;
+          break;
+        case 1:
+          bbox_data[index] = decode_bbox_center_y - decode_bbox_height / 2.;
+          break;
+        case 2:
+          bbox_data[index] = decode_bbox_center_x + decode_bbox_width / 2.;
+          break;
+        case 3:
+          bbox_data[index] = decode_bbox_center_y + decode_bbox_height / 2.;
+          break;
+      }
+    } else if (code_type == caffe::PriorBoxParameter_CodeType_CORNER_SIZE) {
+      const Dtype p_xmin = prior_data[pi];
+      const Dtype p_ymin = prior_data[pi + 1];
+      const Dtype p_xmax = prior_data[pi + 2];
+      const Dtype p_ymax = prior_data[pi + 3];
+      const Dtype prior_width = p_xmax - p_xmin;
+      const Dtype prior_height = p_ymax - p_ymin;
+      Dtype p_size;
+      if (i == 0 || i == 2) {
+        p_size = prior_width;
+      } else {
+        p_size = prior_height;
+      }
+      if (variance_encoded_in_target) {
+        // variance is encoded in target, we simply need to add the offset
+        // predictions.
+        bbox_data[index] = prior_data[pi + i] + loc_data[index] * p_size;
+      } else {
+        // variance is encoded in bbox, we need to scale the offset accordingly.
+        bbox_data[index] =
+          prior_data[pi + i] + loc_data[index] * prior_data[vi + i] * p_size;
+      }
+    } else {
+      // Unknown code type.
+    }
+    if (clip_bbox) {
+      bbox_data[index] = max(min(bbox_data[index], Dtype(1.)), Dtype(0.));
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void PermuteDataKernel(const int nthreads,
+          const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, Dtype* new_data) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    const int i = index % num_dim;
+    const int c = (index / num_dim) % num_classes;
+    const int d = (index / num_dim / num_classes) % num_data;
+    const int n = index / num_dim / num_classes / num_data;
+    const int new_index = ((n * num_classes + c) * num_data + d) * num_dim + i;
+    new_data[new_index] = data[index];
+  }
+}
+
+
+template<>
+bool DetectionOutputOp<float, CUDAContext>::RunOnDevice() {
+  auto& loc = Input(0);
+  auto& conf = Input(1);
+  auto& prior_ = OperatorBase::Input<TensorCPU>(2);
+	auto* Y = OperatorBase::Output<TensorCPU>(0);
+
+  Tensor<CUDAContext> prior;
+  prior.CopyFrom(prior_, &context_);
+
+  const float* loc_data = loc.data<float>();
+	const float* conf_data = conf.data<float>();
+  const float* prior_data = prior.data<float>();
+  const int num = loc.dim(0);
+  
+  bbox_preds_.ResizeLike(loc);
+  if (!share_location_) {
+    bbox_permute_.ResizeLike(loc);
+  }
+  conf_permute_.ResizeLike(conf);
+  
+  float* bbox_data = bbox_preds_.mutable_data<float>();
+  const int loc_count = bbox_preds_.size();
+  const bool clip_bbox = false;
+	const int num_priors_ = prior.dim(2) / 4;
+	CAFFE_ENFORCE_EQ(num_priors_ * num_loc_classes_ * 4, loc.dim(1));
+	CAFFE_ENFORCE_EQ(num_priors_ * num_classes_, conf.dim(1));
+  
+  
+	DecodeBBoxesKernel<float> <<<CAFFE_GET_BLOCKS(loc_count),
+															 CAFFE_CUDA_NUM_THREADS, 0,
+															 context_.cuda_stream()>>> 
+	(loc_count, loc_data, prior_data, code_type_, variance_encoded_in_target_,
+   num_priors_, share_location_, num_loc_classes_, background_label_id_,
+	 clip_bbox, bbox_data);
+  
+  
+	const float* bbox_cpu_data = (float*)malloc(bbox_permute_.size()*sizeof(float));
+	Tensor<CPUContext> bbox_device_data;
+	if (!share_location_) {
+		float* bbox_permute_data = bbox_permute_.mutable_data<float>();
+		PermuteDataKernel<float> <<<CAFFE_GET_BLOCKS(loc_count),
+																CAFFE_CUDA_NUM_THREADS, 0,
+																context_.cuda_stream()>>>
+		(loc_count, bbox_data, num_loc_classes_, num_priors_, 4, bbox_permute_data);
+		bbox_device_data.CopyFrom(bbox_permute_, &context_);
+		bbox_cpu_data = bbox_device_data.data<float>();
+	} else {
+		bbox_device_data.CopyFrom(bbox_preds_, &context_);
+		bbox_cpu_data = bbox_device_data.data<float>();
+	}
+
+	// Retrieve all confidences.
+	float* conf_permute_data = conf_permute_.mutable_data<float>();
+	const int conf_count = conf.size();
+	PermuteDataKernel<float> <<<CAFFE_GET_BLOCKS(conf_count),
+															CAFFE_CUDA_NUM_THREADS, 0,
+															context_.cuda_stream()>>>
+	(conf_count, conf_data, num_classes_, num_priors_, 1, conf_permute_data);
+	Tensor<CPUContext> conf_device_data;
+	conf_device_data.CopyFrom(conf_permute_, &context_);
+	const float* conf_cpu_data = conf_device_data.data<float>();
+
+  // I found CopyFrom use cudaMemcpyAsync, 
+  // here in my opinion should wait and check kernal function finished.
+  CHECK(context_.FinishDeviceComputation());
+	
+  int num_kept = 0;
+	vector<map<int, vector<int> > > all_indices;
+	for (int i = 0; i < num; ++i) {
+		map<int, vector<int> > indices;
+    int num_det = 0;
+    const int conf_idx = i * num_classes_ * num_priors_;
+    int bbox_idx;
+    if (share_location_) {
+      bbox_idx = i * num_priors_ * 4;
+    } else {
+      bbox_idx = conf_idx * 4;
+    }
+    for (int c = 0; c < num_classes_; ++c) {
+      if (c == background_label_id_) {
+        // Ignore background class.
+        continue;
+      }
+      const float* cur_conf_data = conf_cpu_data + conf_idx + c * num_priors_;
+      const float* cur_bbox_data = bbox_cpu_data + bbox_idx;
+      if (!share_location_) {
+        cur_bbox_data += c * num_priors_ * 4;
+      }
+      ApplyNMSFast(cur_bbox_data, cur_conf_data, num_priors_,
+          confidence_threshold_, nms_threshold_, eta_, top_k_, &(indices[c]));
+      num_det += indices[c].size();
+    }
+    if (keep_top_k_ > -1 && num_det > keep_top_k_) {
+      vector<pair<float, pair<int, int> > > score_index_pairs;
+      for (map<int, vector<int> >::iterator it = indices.begin();
+           it != indices.end(); ++it) {
+        int label = it->first;
+        const vector<int>& label_indices = it->second;
+        for (int j = 0; j < label_indices.size(); ++j) {
+          int idx = label_indices[j];
+          float score = conf_cpu_data[conf_idx + label * num_priors_ + idx];
+          score_index_pairs.push_back(std::make_pair(
+                  score, std::make_pair(label, idx)));
+        }
+      }
+      // Keep top k results per image.
+      std::sort(score_index_pairs.begin(), score_index_pairs.end(),
+                SortScorePairDescend<pair<int, int> >);
+      score_index_pairs.resize(keep_top_k_);
+      // Store the new indices.
+      map<int, vector<int> > new_indices;
+      for (int j = 0; j < score_index_pairs.size(); ++j) {
+        int label = score_index_pairs[j].second.first;
+        int idx = score_index_pairs[j].second.second;
+        new_indices[label].push_back(idx);
+      }
+      all_indices.push_back(new_indices);
+      num_kept += keep_top_k_;
+    } else {
+      all_indices.push_back(indices);
+      num_kept += num_det;
+    }
+  }
+	float* top_data;
+	if(num_kept == 0) {
+		LOG(INFO) << "Couldn't find any detections";
+		Y->Resize(1,1,num,7);
+		top_data = Y->mutable_data<float>();
+		// here context_ is CUDAContext, but we need CPUContext.
+		// So i set 0
+		math::Set<float, CPUContext>(num*7, float(-1), top_data, 0);
+		for (int i = 0; i < num; ++i) {
+			top_data[0] = i;
+			top_data += 7;
+		}
+	} else {
+		Y->Resize(1,1,num_kept,7);
+		top_data = Y->mutable_data<float>();
+	}
+
+	int count = 0;
+	for (int i = 0; i < num; ++i) {
+		const int conf_idx = i * num_classes_ * num_priors_;
+		int bbox_idx;
+		if (share_location_) {
+			bbox_idx = i * num_priors_ * 4;
+		} else {
+			bbox_idx = conf_idx * 4;
+		}
+		for (map<int, vector<int> >::iterator it = all_indices[i].begin();
+				it != all_indices[i].end(); ++it) {
+			int label = it->first;
+			vector<int>& indices = it->second;
+			const float* cur_conf_data = conf_cpu_data + conf_idx + label * num_priors_;
+			const float* cur_bbox_data = bbox_cpu_data + bbox_idx;
+			if (!share_location_) {
+				cur_bbox_data += label * num_priors_ * 4;
+			}
+			for (int j = 0; j < indices.size(); ++j) {
+				int idx = indices[j];
+				top_data[count * 7] = i;
+				top_data[count * 7 + 1] = label;
+				top_data[count * 7 + 2] = cur_conf_data[idx];
+				for (int k = 0; k < 4; ++k) {
+					top_data[count * 7 + 3 + k] = cur_bbox_data[idx * 4 + k];
+				}
+        count++;
+			}
+		}
+	}
+
+	return true;
+}
+
+
+namespace caffe {
+
+REGISTER_CUDA_OPERATOR(DetectionOutput, DetectionOutputOp<float, CUDAContext>);
+} // namespace caffe
+
+} // namespace caffe2
+

--- a/caffe2/operators/detection_output_op.h
+++ b/caffe2/operators/detection_output_op.h
@@ -1,0 +1,76 @@
+#ifndef DETECTION_OUTPUT_OP_H_
+#define DETECTION_OUTPUT_OP_H_
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+#include "caffe2/utils/bbox_util.h"
+
+namespace caffe2 {
+template <typename T, class Context>
+class DetectionOutputOp final : public Operator<Context> {
+	public:
+		DetectionOutputOp(const OperatorDef& operator_def, Workspace* ws)
+			: Operator<Context>(operator_def, ws),
+				num_classes_(OperatorBase::GetSingleArgument<int>("num_classes", -1)),
+				share_location_(OperatorBase::GetSingleArgument<bool>("share_location", true)),
+				background_label_id_(OperatorBase::GetSingleArgument<int>("background_label_id", 0)),
+				nms_threshold_(OperatorBase::GetSingleArgument<float>("nms_threshold", 0.3)),
+				top_k_(OperatorBase::GetSingleArgument<int>("top_k", -1)),
+				eta_(OperatorBase::GetSingleArgument<float>("eta", 1.0)),
+				variance_encoded_in_target_(OperatorBase::GetSingleArgument<bool>("variance_encoded_in_target", false)),
+				keep_top_k_(OperatorBase::GetSingleArgument<int>("keep_top_k", -1)),
+				confidence_threshold_(OperatorBase::GetSingleArgument<float>("confidence_threshold", 0.00999999977648)),
+				code_t_(OperatorBase::GetSingleArgument<int>("code_type", 2))	{
+			
+			CAFFE_ENFORCE_GT(num_classes_, 0);
+			CAFFE_ENFORCE_GE(nms_threshold_, 0.);
+			CAFFE_ENFORCE_GT(eta_, 0.);
+			CAFFE_ENFORCE_LE(eta_, 1.);
+			num_loc_classes_ = share_location_ ? 1 : num_classes_;
+			switch(code_t_) {
+			case 1:
+				code_type_ = caffe::PriorBoxParameter_CodeType_CORNER;
+				break;
+			case 2:
+				code_type_ = caffe::PriorBoxParameter_CodeType_CENTER_SIZE;
+				break;
+			case 3:
+				code_type_ = caffe::PriorBoxParameter_CodeType_CORNER_SIZE;
+				break;
+			default:
+				LOG(FATAL) << "Unknown CodeType";
+			}
+		}
+		USE_OPERATOR_CONTEXT_FUNCTIONS;
+		bool RunOnDevice() override;
+	
+	protected:
+		vector<NormalizedBBox> prior_bboxes;
+		int num_loc_classes_;
+		bool share_location_;
+		int num_classes_;
+		int background_label_id_;
+		CodeType code_type_;
+		int code_t_;
+		bool variance_encoded_in_target_;
+		float confidence_threshold_;
+		float nms_threshold_;
+		float eta_;
+		int top_k_;
+		int keep_top_k_;
+    
+    Tensor<Context> bbox_preds_;
+    Tensor<Context> bbox_permute_;
+    Tensor<Context> conf_permute_;
+};
+
+} // namespace caffe2
+
+
+
+#endif
+
+

--- a/caffe2/operators/norm_op.cc
+++ b/caffe2/operators/norm_op.cc
@@ -1,0 +1,114 @@
+#include "caffe2/operators/norm_op.h"
+
+
+namespace caffe2 {
+
+template <>
+bool NormOp<float, CPUContext>::RunOnDevice() {
+	const auto& X = Input(0);
+	const auto& scale = Input(1);
+	auto* Y = Output(0);
+
+	int batch_size = X.dim(0);
+	int channels = X.dim(1);
+	int height = X.dim(2);
+	int width = X.dim(3);
+
+	if(channel_shared_) {
+		CAFFE_ENFORCE_EQ(scale.dim(0), 1);
+	} else {
+		CAFFE_ENFORCE_EQ(scale.dim(0), channels);
+	}
+
+	Y->ResizeLike(X);
+	buffer_.Resize(1, channels, height, width);
+	buffer_channel_.Resize(1, channels, 1, 1);
+	buffer_spatial_.Resize(1, 1, height, width);
+
+	if(across_spatial_) {
+		norm_.Resize(batch_size, 1, 1, 1);
+	} else {
+		norm_.Resize(batch_size, 1, height, width);
+	}
+	sum_channel_multiplier_.Resize(1, channels, 1, 1);
+	math::Set<float, CPUContext>(channels, 
+			float(1.0), sum_channel_multiplier_.template mutable_data<float>(),
+			&context_);
+	int spatial_dim = height * width;
+	sum_spatial_multiplier_.Resize(1, 1, height, width);
+	math::Set<float, CPUContext>(spatial_dim, 
+			float(1.0), sum_spatial_multiplier_.template mutable_data<float>(),
+			&context_);
+
+	const float* Xdata = X.data<float>();
+	const float* Sdata = scale.data<float>();
+	float* buffer_data = buffer_.mutable_data<float>();
+	float* norm_data = norm_.mutable_data<float>();
+	math::Set<float, CPUContext>(norm_.size_from_dim(0),
+			eps_, norm_data, &context_);
+	const float* sum_channel_multiplier = sum_channel_multiplier_.data<float>();
+	const float* sum_spatial_multiplier = sum_spatial_multiplier_.data<float>();
+	float* Ydata = Y->mutable_data<float>();
+	int dim = channels * height * width;
+
+	for(int n = 0; n < batch_size; n++) {
+		math::Sqr<float, CPUContext>(dim, Xdata, buffer_data, &context_);
+		if(across_spatial_) {
+			float accu_sum;
+			math::Sum<float, CPUContext>(dim, buffer_data, &accu_sum, &context_);
+			norm_data[n] = pow(accu_sum+eps_, float(0.5));
+			math::Scale<float, CPUContext>(dim, float(1.0 / norm_data[n]), Xdata, Ydata, 
+					&context_);
+		} else {
+			math::Gemv<float, CPUContext>(CblasTrans, channels, spatial_dim,
+								float(1.0), buffer_data, sum_channel_multiplier, float(1.0),
+								norm_data, &context_);
+			math::Powx<float, CPUContext>(spatial_dim, norm_data, float(0.5), 
+								norm_data, &context_);
+			math::Gemm<float, CPUContext>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+								1, float(1.0), sum_channel_multiplier, norm_data, float(0.0),
+								buffer_data, &context_);
+			math::Div<float, CPUContext>(dim, Xdata, buffer_data, Ydata, &context_);
+			norm_data += spatial_dim;
+		}
+		if (channel_shared_) {
+			math::Scale<float, CPUContext>(dim, Sdata[0], Ydata, Ydata, &context_);
+		} else {
+			math::Gemm<float, CPUContext>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+								1, float(1.0), Sdata, sum_spatial_multiplier, float(0.0), buffer_data,
+								&context_);
+			math::Mul<float, CPUContext>(dim, Ydata, buffer_data, Ydata, &context_);
+		}
+		Xdata += dim;
+		Ydata += dim;
+	}
+	return true;
+}
+
+
+namespace {
+
+REGISTER_CPU_OPERATOR(Norm, NormOp<float, CPUContext>);
+NO_GRADIENT(Norm);
+
+// Input: X, scale
+// Output: Y
+OPERATOR_SCHEMA(Norm)
+		.NumInputs(2)
+		.NumOutputs(1)
+		.IdenticalTypeAndShape()
+		.SetDoc(R"Doc(SSD L2 and Scale layer)Doc")
+		.Arg("across_spatial", "default: false")
+		.Arg("order", "default: NCHW")
+		.Arg("eps", "default: 10e-10")
+		.Arg("channel_shared", "default: false")
+		.Input(0, "X", "NCHW tensor")
+		.Input(1, "scale", "scale factor")
+		.Output(0, "Y", "NCHW tensor");
+
+} // namespace
+
+
+} // namespace caffe2
+
+

--- a/caffe2/operators/norm_op.cu
+++ b/caffe2/operators/norm_op.cu
@@ -1,0 +1,115 @@
+#include "caffe2/operators/norm_op.h"
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+namespace {
+
+// divid a matrix with vector
+template <typename T>
+__global__ void DivBsx(const int nthreads, const T* A,
+    const T* v, const int rows, const int cols, const CBLAS_TRANSPOSE trans,
+    T* B) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    int c = index % cols;
+    int r = (index / cols) % rows;
+    if (trans == CblasNoTrans) {
+      B[index] = A[index] / v[c];
+    } else {
+      B[index] = A[index] / v[r];
+    }
+  }
+}
+
+template <typename T>
+__global__ void MulBsx(const int nthreads, const T* A,
+    const T* v, const int rows, const int cols, const CBLAS_TRANSPOSE trans,
+   	T* B) {
+  CUDA_1D_KERNEL_LOOP(index, nthreads) {
+    int c = index % cols;
+    int r = (index / cols) % rows;
+    if (trans == CblasNoTrans) {
+      B[index] = A[index] * v[c];
+    } else {
+      B[index] = A[index] * v[r];
+    }
+  }
+}
+
+REGISTER_CUDA_OPERATOR(Norm, NormOp<float, CUDAContext>);
+} // namespace
+
+template <>
+bool NormOp<float, CUDAContext>::RunOnDevice() {
+	auto& X = Input(0);
+	auto& scale = Input(1);
+	auto* Y = Output(0);
+
+	int batch_size = X.dim(0);
+	int channels = X.dim(1);
+	int height = X.dim(2);
+	int width = X.dim(3);
+
+	Y->ResizeLike(X);
+	buffer_.Resize(1, channels, height, width);
+	buffer_channel_.Resize(1, channels, 1, 1);
+	buffer_spatial_.Resize(1, 1, height, width);
+
+	if(across_spatial_) {
+		norm_.Resize(batch_size, 1, 1, 1);
+	} else {
+		norm_.Resize(batch_size, 1, height, width);
+	}
+	sum_channel_multiplier_.Resize(1, channels, 1, 1);
+	math::Set<float, CUDAContext>(channels,
+			float(1.0), sum_channel_multiplier_.mutable_data<float>(),
+			&context_);
+	int spatial_dim = height * width;
+	sum_spatial_multiplier_.Resize(1, 1, height, width);
+	math::Set<float, CUDAContext>(spatial_dim,
+			float(1.0), sum_spatial_multiplier_.mutable_data<float>(),
+			&context_);
+
+	const float* Xdata = X.data<float>();
+	const float* Sdata = scale.data<float>();
+	float* buffer_data = buffer_.mutable_data<float>();
+	float* norm_data = norm_.mutable_data<float>();
+	math::Set<float, CUDAContext>(norm_.size_from_dim(0),
+			eps_, norm_data, &context_);
+	const float* sum_channel_multiplier = sum_channel_multiplier_.data<float>();
+	const float* sum_spatial_multiplier = sum_spatial_multiplier_.data<float>();
+	float* Ydata = Y->mutable_data<float>();
+	int dim = channels * height * width;
+
+	for(int n = 0; n < batch_size; n++) {
+		math::Powx<float, CUDAContext>(dim, Xdata, float(2.0), buffer_data, &context_);
+		if(across_spatial_) {
+			float accu_sum;
+			math::Sum<float, CUDAContext>(dim, buffer_data, &accu_sum, &context_);
+			norm_data[n] = pow(accu_sum+eps_, float(0.5));
+			math::Scale<float, CUDAContext>(dim, float(1.0 / norm_data[n]), Xdata, Ydata,
+					&context_);
+		} else {
+			math::Gemv<float, CUDAContext>(CblasTrans, channels, spatial_dim,
+								float(1.0), buffer_data, sum_channel_multiplier, float(1.0),
+								norm_data, &context_);
+			math::Powx<float, CUDAContext>(spatial_dim, norm_data, float(0.5),
+								norm_data, &context_);
+			DivBsx<float> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS, 0, 
+				context_.cuda_stream()>>> (
+					dim, Xdata, norm_data, channels, spatial_dim, CblasNoTrans, Ydata);
+			norm_data += spatial_dim;
+		}
+		if (channel_shared_) {
+			math::Scale<float, CUDAContext>(dim, Sdata[0], Ydata, Ydata, &context_);
+		} else {
+			MulBsx<float> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS, 0, 
+				context_.cuda_stream()>>> (
+					dim, Ydata, Sdata, channels, spatial_dim, CblasTrans, Ydata);
+		}
+		Xdata += dim;
+		Ydata += dim;
+	}
+	return true;
+}
+
+} // namespace caffe2

--- a/caffe2/operators/norm_op.h
+++ b/caffe2/operators/norm_op.h
@@ -1,0 +1,41 @@
+#ifndef NORM_OP_H_
+#define NORM_OP_H
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <typename T, class Context>
+class NormOp final : public Operator<Context> {
+	public:
+		NormOp(const OperatorDef& operator_def, Workspace* ws)
+			: Operator<Context>(operator_def, ws),
+				across_spatial_(OperatorBase::GetSingleArgument<bool>("across_spatial", false)),
+				order_(StringToStorageOrder(
+							OperatorBase::GetSingleArgument<string>("order", "NCHW"))),
+				eps_(OperatorBase::GetSingleArgument<float>("eps", 10e-10)),
+				channel_shared_(OperatorBase::GetSingleArgument<bool>("channel_shared", false)) {
+			CAFFE_ENFORCE_EQ(order_, StorageOrder::NCHW, "Only NCHW order is supported right now.");
+		}
+		USE_OPERATOR_CONTEXT_FUNCTIONS;
+		bool RunOnDevice() override;
+	
+	protected:
+		bool across_spatial_;
+		StorageOrder order_;
+		float eps_;
+		bool channel_shared_;
+		Tensor<Context> buffer_, buffer_channel_, buffer_spatial_;
+		Tensor<Context> norm_;
+		Tensor<Context> sum_channel_multiplier_, sum_spatial_multiplier_;
+};
+
+
+} // namepsace caffe2
+
+
+
+#endif // NORM_OP_H_

--- a/caffe2/operators/prior_box_op.cc
+++ b/caffe2/operators/prior_box_op.cc
@@ -1,0 +1,163 @@
+#include "caffe2/operators/prior_box_op.h"
+
+namespace caffe2 {
+
+template<>
+bool PriorBoxOp<float, CPUContext>::RunOnDevice() {
+	const auto& X = Input(0);
+	const auto& data = Input(1);
+	auto* Y = Output(0);
+	
+	const int layer_height = X.dim(2);
+	const int layer_width = X.dim(3);
+	int img_height, img_width;
+	if (img_h_ == 0 || img_w_ == 0) {
+		img_height = data.dim(2);
+		img_width = data.dim(3);
+	} else {
+		img_height = img_h_;
+		img_width = img_w_;
+	}
+	float step_w, step_h;
+	if (step_w_ == 0 || step_h_ == 0) {
+		step_h = static_cast<float>(img_height) / layer_height;
+		step_w = static_cast<float>(img_width) / layer_width;
+	} else {
+		step_h = step_h_;
+		step_w = step_w_;
+	}
+	int dim = layer_height * layer_width * num_priors_ * 4;
+	Y->Resize(1, 2, dim);
+	int idx = 0;
+	float* top_data = Y->mutable_data<float>();
+	for(int h = 0; h < layer_height; ++h) {
+		for(int w = 0; w < layer_width; ++w) {
+			float center_x = (w + offset_) * step_w;
+			float center_y = (h + offset_) * step_h;
+			float box_width, box_height;
+			for(int s = 0; s < min_sizes_.size(); ++s) {
+				int min_size_ = min_sizes_[s];
+				box_width = box_height = min_size_;
+				top_data[idx++] = (center_x - box_width / 2.) / img_width;
+				top_data[idx++] = (center_y - box_height / 2.) / img_height;
+				top_data[idx++] = (center_x + box_width / 2.) / img_width;
+				top_data[idx++] = (center_y + box_height / 2.) / img_height;
+
+				if (max_sizes_.size() > 0) {
+					CAFFE_ENFORCE_EQ(min_sizes_.size(), max_sizes_.size());
+					int max_size_ = max_sizes_[s];
+					box_width = box_height = sqrt(min_size_ * max_size_);
+					top_data[idx++] = (center_x - box_width / 2.) / img_width;
+					top_data[idx++] = (center_y - box_height / 2.) / img_height;
+					top_data[idx++] = (center_x + box_width / 2.) / img_width;
+					top_data[idx++] = (center_y + box_height / 2.) / img_height;
+				}
+				for (int r = 0; r < aspts_.size(); ++r) {
+					float ar = aspts_[r];
+					if (fabs(ar - 1.) < 1e-6) {
+						continue;
+					}
+					box_width = min_size_ * sqrt(ar);
+					box_height = min_size_ / sqrt(ar);
+					top_data[idx++] = (center_x - box_width / 2.) / img_width;
+					top_data[idx++] = (center_y - box_height / 2.) / img_height;
+					top_data[idx++] = (center_x + box_width / 2.) / img_width;
+					top_data[idx++] = (center_y + box_height / 2.) / img_height;
+				}
+			}
+		}
+	}
+	if (clip_) {
+		for (int d = 0; d < dim; ++d) {
+			top_data[d] = std::min<float>(std::max<float>(top_data[d], 0.), 1.);
+		}
+	}
+
+	top_data += dim;
+	if (variance_.size() == 1) {
+		math::Set<float, CPUContext>(dim, float(variance_[0]), top_data, &context_);
+	} else {
+		int count = 0;
+		for (int h = 0; h < layer_height; ++h) {
+			for (int w = 0; w < layer_width; ++w) {
+				for (int i = 0; i < num_priors_; ++i) {
+					for (int j = 0; j < 4; ++j) {
+						top_data[count] = variance_[j];
+						++count;
+					}
+				}
+			}
+		}
+	}
+}
+
+namespace {
+REGISTER_CPU_OPERATOR(PriorBox, PriorBoxOp<float, CPUContext>);
+NO_GRADIENT(PriorBox);
+
+OPERATOR_SCHEMA(PriorBox)
+	.NumInputs(2)
+	.NumOutputs(1)
+	.TensorInferenceFunction(
+		[](const OperatorDef& def, const vector<TensorShape>& in) {
+			ArgumentHelper helper(def);
+			const StorageOrder order = StringToStorageOrder(
+					helper.GetSingleArgument<string>("order", "NCHW"));
+			const TensorShape &X = in[0];
+			int layer_height = X.dims(2); int layer_width = X.dims(3);
+			
+			vector<float> aspects = helper.GetRepeatedArgument<float>("aspect_ratios");
+			vector<float> min_sizes = helper.GetRepeatedArgument<float>("min_sizes");
+			vector<float> aspts;
+			aspts.push_back(1);
+			bool flip = helper.GetSingleArgument<bool>("flip", true);
+			for(int i = 0; i < aspects.size(); i++) {
+				float ar = aspects[i];
+				bool already_exist = false;
+				for(int j = 0; j < aspts.size(); j++) {
+					if (fabs(ar - aspts[j]) < 1e-6) {
+						already_exist = true;
+						break;
+					}
+				}
+				if(!already_exist) {
+					aspts.push_back(ar);
+					if(flip) {
+						aspts.push_back(1./ar);
+					}
+				}
+			}
+
+			int num_priors_ = aspts.size() * min_sizes.size();
+			vector<float> max_sizes = helper.GetRepeatedArgument<float>("max_sizes");
+			for(int i = 0; i < max_sizes.size(); i++)
+				num_priors_ += 1;
+
+			TensorShape Y = CreateTensorShape(
+					vector<int>({1, 2, layer_width * layer_height * num_priors_ * 4}),
+					X.data_type());
+			return vector<TensorShape>({Y});
+		})
+	.SetDoc(R"DOC(PriorBoxLayer in SSD)DOC")
+	.Arg("min_sizes", "repeated min_sizes")
+	.Arg("max_sizes", "optional max_sizes")
+	.Arg("aspect_ratios", "repeated aspect ratios")
+	.Arg("flip", "1 / ar")
+	.Arg("clip", "clip box")
+	.Arg("variance", "prior variance")
+	.Arg("img_size", "image size")
+	.Arg("img_w", "image width")
+	.Arg("img_h", "image height")
+	.Arg("step", "feature stride")
+	.Arg("step_h", "step height")
+	.Arg("step_w", "step width")
+	.Arg("offset", "offset")
+	.Arg("order", "NCHW")
+	.Input(0, "X", "NCHW tensor")
+	.Input(1, "data", "NCHW input tensor")
+	.Output(0, "Y", "prior boxes");
+
+} // namespace
+
+
+} // namespace caffe2

--- a/caffe2/operators/prior_box_op.h
+++ b/caffe2/operators/prior_box_op.h
@@ -1,0 +1,139 @@
+#ifndef PRIOR_BOX_OP_H_
+#define PRIOR_BOX_OP_H_
+
+#include "caffe2/core/context.h"
+#include "caffe2/core/logging.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <typename T, class Context>
+class PriorBoxOp final : public Operator<Context> {
+	public:
+		PriorBoxOp(const OperatorDef& operator_def, Workspace* ws)
+			: Operator<Context>(operator_def, ws),
+				min_sizes_(OperatorBase::GetRepeatedArgument<float>("min_sizes")),
+				max_sizes_(OperatorBase::GetRepeatedArgument<float>("max_sizes")),
+				aspect_ratios_(OperatorBase::GetRepeatedArgument<float>("aspect_ratios")),
+				flip_(OperatorBase::GetSingleArgument<bool>("flip", true)),
+				clip_(OperatorBase::GetSingleArgument<bool>("clip", false)),
+				variance_(OperatorBase::GetRepeatedArgument<float>("variance")),
+				img_size_(OperatorBase::GetSingleArgument<int>("img_size", 0)),
+				img_w_(OperatorBase::GetSingleArgument<int>("img_w", 0)),
+				img_h_(OperatorBase::GetSingleArgument<int>("img_h", 0)),
+				step_(OperatorBase::GetSingleArgument<float>("step", 0.)),
+				step_h_(OperatorBase::GetSingleArgument<float>("step_h", 0.)),
+				step_w_(OperatorBase::GetSingleArgument<float>("step_w", 0.)),
+				offset_(OperatorBase::GetSingleArgument<float>("offset", 0.5)),
+				order_(StringToStorageOrder(
+					OperatorBase::GetSingleArgument<string>("order", "NCHW"))) {
+			
+			// check order
+			CAFFE_ENFORCE_EQ(order_, 
+						StorageOrder::NCHW, "Only NCHW order is supported right now.");
+			
+			// check min_sizes
+			CAFFE_ENFORCE_GT(min_sizes_.size(), 0);
+			for(int i = 0; i < min_sizes_.size(); i++) {
+				CAFFE_ENFORCE_GT(min_sizes_[i], 0);
+			}
+
+			// set aspts_
+			aspts_.clear();
+			aspts_.push_back(1.);
+			for(int i = 0; i < aspect_ratios_.size(); i++) {
+				float ar = aspect_ratios_[i];
+				bool already_exist = false;
+				for(int j = 0; j < aspts_.size(); j++) {
+					if (fabs(ar - aspts_[j]) < 1e-6) {
+						already_exist = true;
+						break;
+					}
+				}
+				if (!already_exist) {
+					aspts_.push_back(ar);
+					if (flip_) {
+						aspts_.push_back(1./ar);
+					}
+				}
+			}
+
+			// set num_priors and check max_sizes
+			num_priors_ = aspts_.size() * min_sizes_.size();
+			if(max_sizes_.size() > 0) {
+				CAFFE_ENFORCE_EQ(max_sizes_.size(), min_sizes_.size());
+				for(int i = 0; i < max_sizes_.size(); i++) {
+					CAFFE_ENFORCE_GT(max_sizes_[i], min_sizes_[i]);
+					num_priors_ += 1;
+				}
+			}
+
+			// check and set variance
+			if(variance_.size() > 1) {
+				CAFFE_ENFORCE_EQ(variance_.size(), 4);
+				for(int i = 0; i < variance_.size(); i++) {
+					CAFFE_ENFORCE_GT(variance_[i], 0);
+				}
+			} else if(variance_.size() == 1) {
+				CAFFE_ENFORCE_GT(variance_[0], 0);
+			} else {
+				variance_.push_back(0.1);
+			}
+
+			// check img_size and set img_h_,img_w_
+			if(img_h_ != 0 || img_w_ != 0) {
+				CAFFE_ENFORCE_EQ(img_size_, 0);
+				CAFFE_ENFORCE_GT(img_h_, 0);
+				CAFFE_ENFORCE_GT(img_w_, 0);
+			} else if(img_size_ != 0) {
+				CAFFE_ENFORCE_GT(img_size_, 0);
+				img_h_ = img_size_;
+				img_w_ = img_size_;
+			} else {
+				img_h_ = 0;
+				img_w_ = 0;
+			}
+
+			// check step and set step_h_, step_w_
+			if(step_h_ != 0. || step_w_ != 0.) {
+				CAFFE_ENFORCE_EQ(step_, 0.);
+				CAFFE_ENFORCE_GT(step_h_, 0.);
+				CAFFE_ENFORCE_GT(step_w_, 0.);
+			} else if(step_ != 0.) {
+				CAFFE_ENFORCE_GT(step_, 0.);
+				step_h_ = step_;
+				step_w_ = step_;
+			} else {
+				step_h_ = 0.;
+				step_w_ = 0.;
+			}
+
+		}
+		USE_OPERATOR_CONTEXT_FUNCTIONS;
+		bool RunOnDevice() override;
+
+	protected:
+		vector<float> min_sizes_;
+		vector<float> max_sizes_;
+		vector<float> aspect_ratios_;
+		vector<float> aspts_;
+
+		bool flip_;
+		int num_priors_;
+		bool clip_;
+		vector<float> variance_;
+
+		int img_size_;
+		int img_w_;
+		int img_h_;
+		float step_;
+		float step_w_;
+		float step_h_;
+		float offset_;
+		StorageOrder order_;
+};
+
+} // namespace caffe2
+
+#endif // PRIOR_BOX_OP_H_

--- a/caffe2/python/caffe_translator.py
+++ b/caffe2/python/caffe_translator.py
@@ -22,6 +22,7 @@ import copy
 import logging
 import re
 import numpy as np  # noqa
+import sys
 
 from caffe2.proto import caffe2_pb2, caffe2_legacy_pb2
 from caffe.proto import caffe_pb2
@@ -888,6 +889,72 @@ def TranslateReduction(layer, pretrained_blobs, is_test, **kwargs):
         raise NotImplementedError("Not yet supported")
     num_reduce_dim = -param.axis
     AddArgument(caffe_op, "num_reduce_dim", num_reduce_dim)
+
+    return caffe_op, []
+
+
+@TranslatorRegistry.Register("Normalize")
+def TranslateNormalize(layer, pretrained_blobs, is_test, **kwargs):
+    caffe_op = BaseTranslate(layer, "Norm")
+    output = caffe_op.output[0]
+    param = layer.norm_param
+    AddArgument(caffe_op, "across_spatial", param.across_spatial)
+    AddArgument(caffe_op, "eps", param.eps)
+    AddArgument(caffe_op, "channel_shared", param.channel_shared)
+    AddArgument(caffe_op, "order", "NCHW")
+
+    caffe_op.input.extend([output + "_scale"])
+    scale = utils.NumpyArrayToCaffe2Tensor(pretrained_blobs[0], output + '_scale')
+    
+
+    return caffe_op, [scale]
+
+@TranslatorRegistry.Register("PriorBox")
+def TranslatePriorBox(layer, pretrained_blobs, is_test, **kwargs):
+    caffe_op = BaseTranslate(layer, "PriorBox")
+    output = caffe_op.output[0]
+    param = layer.prior_box_param
+    AddArgument(caffe_op, "min_sizes", [param.min_size[i] for i in range(len(param.min_size))])
+    AddArgument(caffe_op, "max_sizes", [param.max_size[i] for i in range(len(param.max_size))])
+    AddArgument(caffe_op, "aspect_ratios", [param.aspect_ratio[i] for i in range(len(param.aspect_ratio))])
+    AddArgument(caffe_op, "flip", param.flip)
+    AddArgument(caffe_op, "clip", param.clip)
+    AddArgument(caffe_op, "variance", [param.variance[i] for i in range(len(param.variance))])
+    AddArgument(caffe_op, "img_size", param.img_size)
+    AddArgument(caffe_op, "img_w", param.img_w)
+    AddArgument(caffe_op, "img_h", param.img_h)
+    AddArgument(caffe_op, "step", param.step)
+    AddArgument(caffe_op, "step_h", param.step_h)
+    AddArgument(caffe_op, "step_w", param.step_w)
+    AddArgument(caffe_op, "offset", param.offset)
+    AddArgument(caffe_op, "order", "NCHW")
+
+    return caffe_op, []
+
+@TranslatorRegistry.Register("Permute")
+def TranslatePermute(layer, pretrained_blobs, is_test, **kwargs):
+    caffe_op = BaseTranslate(layer, "Transpose")
+    param = layer.permute_param
+    num_orders = len(param.order)
+    assert num_orders == 4
+    AddArgument(caffe_op, "axes", [param.order[i] for i in range(num_orders)])
+
+    return caffe_op, []
+
+@TranslatorRegistry.Register("DetectionOutput")
+def TranslateDetectionOutput(layer, pretrained_blobs, is_test, **kwargs):
+    caffe_op = BaseTranslate(layer, "DetectionOutput")
+    param = layer.detection_output_param
+    AddArgument(caffe_op, "num_classes", param.num_classes)
+    AddArgument(caffe_op, "share_location", param.share_location)
+    AddArgument(caffe_op, "background_label_id", param.background_label_id)
+    AddArgument(caffe_op, "nms_threshold", param.nms_param.nms_threshold)
+    AddArgument(caffe_op, "top_k", param.nms_param.top_k)
+    AddArgument(caffe_op, "eta", param.nms_param.eta)
+    AddArgument(caffe_op, "code_type", param.code_type)
+    AddArgument(caffe_op, "variance_encoded_in_target", param.variance_encoded_in_target)
+    AddArgument(caffe_op, "keep_top_k", param.keep_top_k)
+    AddArgument(caffe_op, "confidence_threshold", param.confidence_threshold)
 
     return caffe_op, []
 

--- a/caffe2/utils/bbox_util.cc
+++ b/caffe2/utils/bbox_util.cc
@@ -1,0 +1,494 @@
+#include <algorithm>
+#include <csignal>
+#include <ctime>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe2/utils/bbox_util.h"
+
+namespace caffe2 {
+
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds) {
+  loc_preds->clear();
+  if (share_location) {
+    CAFFE_ENFORCE_EQ(num_loc_classes, 1);
+  }
+  loc_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    LabelBBox& label_bbox = (*loc_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_loc_classes * 4;
+      for (int c = 0; c < num_loc_classes; ++c) {
+        int label = share_location ? -1 : c;
+        if (label_bbox.find(label) == label_bbox.end()) {
+          label_bbox[label].resize(num_preds_per_class);
+        }
+        label_bbox[label][p].set_xmin(loc_data[start_idx + c * 4]);
+        label_bbox[label][p].set_ymin(loc_data[start_idx + c * 4 + 1]);
+        label_bbox[label][p].set_xmax(loc_data[start_idx + c * 4 + 2]);
+        label_bbox[label][p].set_ymax(loc_data[start_idx + c * 4 + 3]);
+      }
+    }
+    loc_data += num_preds_per_class * num_loc_classes * 4;
+  }
+}
+// Explicit initialization.
+template void GetLocPredictions(const float* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds) {
+  conf_preds->clear();
+  conf_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<float> >& label_scores = (*conf_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      for (int c = 0; c < num_classes; ++c) {
+        label_scores[c].push_back(conf_data[start_idx + c]);
+      }
+    }
+    conf_data += num_preds_per_class * num_classes;
+  }
+}
+// Explicit initialization.
+template void GetConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances) {
+  prior_bboxes->clear();
+  prior_variances->clear();
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = i * 4;
+    NormalizedBBox bbox;
+    bbox.set_xmin(prior_data[start_idx]);
+    bbox.set_ymin(prior_data[start_idx + 1]);
+    bbox.set_xmax(prior_data[start_idx + 2]);
+    bbox.set_ymax(prior_data[start_idx + 3]);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    prior_bboxes->push_back(bbox);
+  }
+
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = (num_priors + i) * 4;
+    vector<float> var;
+    for (int j = 0; j < 4; ++j) {
+      var.push_back(prior_data[start_idx + j]);
+    }
+    prior_variances->push_back(var);
+  }
+}
+
+// Explicit initialization.
+template void GetPriorBBoxes(const float* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized) {
+  if (bbox.xmax() < bbox.xmin() || bbox.ymax() < bbox.ymin()) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return 0;
+  } else {
+    if (bbox.has_size()) {
+      return bbox.size();
+    } else {
+      float width = bbox.xmax() - bbox.xmin();
+      float height = bbox.ymax() - bbox.ymin();
+      if (normalized) {
+        return width * height;
+      } else {
+        // If bbox is not within range [0, 1].
+        return (width + 1) * (height + 1);
+      }
+    }
+  }
+}
+
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_preds,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip, vector<LabelBBox>* all_decode_bboxes) {
+  CAFFE_ENFORCE_EQ(all_loc_preds.size(), num);
+  all_decode_bboxes->clear();
+  all_decode_bboxes->resize(num);
+  for (int i = 0; i < num; ++i) {
+    // Decode predictions into bboxes.
+    LabelBBox& decode_bboxes = (*all_decode_bboxes)[i];
+    for (int c = 0; c < num_loc_classes; ++c) {
+      int label = share_location ? -1 : c;
+      if (label == background_label_id) {
+        // Ignore background class.
+        continue;
+      }
+      if (all_loc_preds[i].find(label) == all_loc_preds[i].end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for label " << label;
+      }
+      const vector<NormalizedBBox>& label_loc_preds =
+          all_loc_preds[i].find(label)->second;
+      DecodeBBoxes(prior_bboxes, prior_variances,
+                   code_type, variance_encoded_in_target, clip,
+                   label_loc_preds, &(decode_bboxes[label]));
+    }
+  }
+}
+
+void DecodeBBoxes(
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes) {
+  CAFFE_ENFORCE_EQ(prior_bboxes.size(), prior_variances.size());
+  CAFFE_ENFORCE_EQ(prior_bboxes.size(), bboxes.size());
+  int num_bboxes = prior_bboxes.size();
+  if (num_bboxes >= 1) {
+  	CAFFE_ENFORCE_EQ(prior_variances[0].size(), 4);
+  }
+  decode_bboxes->clear();
+  for (int i = 0; i < num_bboxes; ++i) {
+    NormalizedBBox decode_bbox;
+    DecodeBBox(prior_bboxes[i], prior_variances[i], code_type,
+               variance_encoded_in_target, clip_bbox, bboxes[i], &decode_bbox);
+    decode_bboxes->push_back(decode_bbox);
+  }
+}
+void DecodeBBox(
+    const NormalizedBBox& prior_bbox, const vector<float>& prior_variance,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const NormalizedBBox& bbox,
+    NormalizedBBox* decode_bbox) {
+  if (code_type == caffe::PriorBoxParameter_CodeType_CORNER) {
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      decode_bbox->set_xmin(prior_bbox.xmin() + bbox.xmin());
+      decode_bbox->set_ymin(prior_bbox.ymin() + bbox.ymin());
+      decode_bbox->set_xmax(prior_bbox.xmax() + bbox.xmax());
+      decode_bbox->set_ymax(prior_bbox.ymax() + bbox.ymax());
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox->set_xmin(
+          prior_bbox.xmin() + prior_variance[0] * bbox.xmin());
+      decode_bbox->set_ymin(
+          prior_bbox.ymin() + prior_variance[1] * bbox.ymin());
+      decode_bbox->set_xmax(
+          prior_bbox.xmax() + prior_variance[2] * bbox.xmax());
+      decode_bbox->set_ymax(
+          prior_bbox.ymax() + prior_variance[3] * bbox.ymax());
+    }
+  } else if (code_type == caffe::PriorBoxParameter_CodeType_CENTER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CAFFE_ENFORCE_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CAFFE_ENFORCE_GT(prior_height, 0);
+    float prior_center_x = (prior_bbox.xmin() + prior_bbox.xmax()) / 2.;
+    float prior_center_y = (prior_bbox.ymin() + prior_bbox.ymax()) / 2.;
+
+    float decode_bbox_center_x, decode_bbox_center_y;
+    float decode_bbox_width, decode_bbox_height;
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to retore the offset
+      // predictions.
+      decode_bbox_center_x = bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y = bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width = exp(bbox.xmax()) * prior_width;
+      decode_bbox_height = exp(bbox.ymax()) * prior_height;
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox_center_x =
+          prior_variance[0] * bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y =
+          prior_variance[1] * bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width =
+          exp(prior_variance[2] * bbox.xmax()) * prior_width;
+      decode_bbox_height =
+          exp(prior_variance[3] * bbox.ymax()) * prior_height;
+    }
+
+    decode_bbox->set_xmin(decode_bbox_center_x - decode_bbox_width / 2.);
+    decode_bbox->set_ymin(decode_bbox_center_y - decode_bbox_height / 2.);
+    decode_bbox->set_xmax(decode_bbox_center_x + decode_bbox_width / 2.);
+    decode_bbox->set_ymax(decode_bbox_center_y + decode_bbox_height / 2.);
+  } else if (code_type == caffe::PriorBoxParameter_CodeType_CORNER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CAFFE_ENFORCE_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CAFFE_ENFORCE_GT(prior_height, 0);
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      decode_bbox->set_xmin(prior_bbox.xmin() + bbox.xmin() * prior_width);
+      decode_bbox->set_ymin(prior_bbox.ymin() + bbox.ymin() * prior_height);
+      decode_bbox->set_xmax(prior_bbox.xmax() + bbox.xmax() * prior_width);
+      decode_bbox->set_ymax(prior_bbox.ymax() + bbox.ymax() * prior_height);
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox->set_xmin(
+          prior_bbox.xmin() + prior_variance[0] * bbox.xmin() * prior_width);
+      decode_bbox->set_ymin(
+          prior_bbox.ymin() + prior_variance[1] * bbox.ymin() * prior_height);
+      decode_bbox->set_xmax(
+          prior_bbox.xmax() + prior_variance[2] * bbox.xmax() * prior_width);
+      decode_bbox->set_ymax(
+          prior_bbox.ymax() + prior_variance[3] * bbox.ymax() * prior_height);
+    }
+  } else {
+    LOG(FATAL) << "Unknown LocLossType.";
+  }
+  float bbox_size = BBoxSize(*decode_bbox);
+  decode_bbox->set_size(bbox_size);
+  if (clip_bbox) {
+    ClipBBox(*decode_bbox, decode_bbox);
+  }
+}
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox) {
+  clip_bbox->set_xmin(std::max(std::min(bbox.xmin(), 1.f), 0.f));
+  clip_bbox->set_ymin(std::max(std::min(bbox.ymin(), 1.f), 0.f));
+  clip_bbox->set_xmax(std::max(std::min(bbox.xmax(), 1.f), 0.f));
+  clip_bbox->set_ymax(std::max(std::min(bbox.ymax(), 1.f), 0.f));
+  clip_bbox->clear_size();
+  clip_bbox->set_size(BBoxSize(*clip_bbox));
+  clip_bbox->set_difficult(bbox.difficult());
+}
+
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices) {
+  // Sanity check.
+  CAFFE_ENFORCE_EQ(bboxes.size(), scores.size());
+
+  // Get top_k scores (with corresponding indices).
+  vector<pair<float, int> > score_index_vec;
+  GetMaxScoreIndex(scores, score_threshold, top_k, &score_index_vec);
+
+  // Do nms.
+  float adaptive_threshold = nms_threshold;
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    const int idx = score_index_vec.front().second;
+    bool keep = true;
+    for (int k = 0; k < indices->size(); ++k) {
+      if (keep) {
+        const int kept_idx = (*indices)[k];
+        float overlap = JaccardOverlap(bboxes[idx], bboxes[kept_idx]);
+        keep = overlap <= adaptive_threshold;
+      } else {
+        break;
+      }
+    }
+    if (keep) {
+      indices->push_back(idx);
+    }
+    score_index_vec.erase(score_index_vec.begin());
+    if (keep && eta < 1 && adaptive_threshold > 0.5) {
+      adaptive_threshold *= eta;
+    }
+  }
+}
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec) {
+  // Generate index score pairs.
+  for (int i = 0; i < scores.size(); ++i) {
+    if (scores[i] > threshold) {
+      score_index_vec->push_back(std::make_pair(scores[i], i));
+    }
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::stable_sort(score_index_vec->begin(), score_index_vec->end(),
+                   SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2) {
+  return pair1.first > pair2.first;
+}
+
+// Explicit initialization.
+template bool SortScorePairDescend(const pair<float, int>& pair1,
+                                   const pair<float, int>& pair2);
+template bool SortScorePairDescend(const pair<float, pair<int, int> >& pair1,
+                                   const pair<float, pair<int, int> >& pair2);
+
+
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized) {
+  NormalizedBBox intersect_bbox;
+  IntersectBBox(bbox1, bbox2, &intersect_bbox);
+  float intersect_width, intersect_height;
+  if (normalized) {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin();
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin();
+  } else {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin() + 1;
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin() + 1;
+  }
+  if (intersect_width > 0 && intersect_height > 0) {
+    float intersect_size = intersect_width * intersect_height;
+    float bbox1_size = BBoxSize(bbox1);
+    float bbox2_size = BBoxSize(bbox2);
+    return intersect_size / (bbox1_size + bbox2_size - intersect_size);
+  } else {
+    return 0.;
+  }
+}
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox) {
+  if (bbox2.xmin() > bbox1.xmax() || bbox2.xmax() < bbox1.xmin() ||
+      bbox2.ymin() > bbox1.ymax() || bbox2.ymax() < bbox1.ymin()) {
+    // Return [0, 0, 0, 0] if there is no intersection.
+    intersect_bbox->set_xmin(0);
+    intersect_bbox->set_ymin(0);
+    intersect_bbox->set_xmax(0);
+    intersect_bbox->set_ymax(0);
+  } else {
+    intersect_bbox->set_xmin(std::max(bbox1.xmin(), bbox2.xmin()));
+    intersect_bbox->set_ymin(std::max(bbox1.ymin(), bbox2.ymin()));
+    intersect_bbox->set_xmax(std::min(bbox1.xmax(), bbox2.xmax()));
+    intersect_bbox->set_ymax(std::min(bbox1.ymax(), bbox2.ymax()));
+  }
+}
+
+template <typename Dtype>
+void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices) {
+  // Get top_k scores (with corresponding indices).
+  vector<pair<Dtype, int> > score_index_vec;
+  GetMaxScoreIndex(scores, num, score_threshold, top_k, &score_index_vec);
+
+  // Do nms.
+  float adaptive_threshold = nms_threshold;
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    const int idx = score_index_vec.front().second;
+    bool keep = true;
+    for (int k = 0; k < indices->size(); ++k) {
+      if (keep) {
+        const int kept_idx = (*indices)[k];
+        float overlap = JaccardOverlap(bboxes + idx * 4, bboxes + kept_idx * 4);
+        keep = overlap <= adaptive_threshold;
+      } else {
+        break;
+      }
+    }
+    if (keep) {
+      indices->push_back(idx);
+    }
+    score_index_vec.erase(score_index_vec.begin());
+    if (keep && eta < 1 && adaptive_threshold > 0.5) {
+      adaptive_threshold *= eta;
+    }
+  }
+}
+
+template
+void ApplyNMSFast(const float* bboxes, const float* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+template
+void ApplyNMSFast(const double* bboxes, const double* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+
+
+template <typename Dtype>
+void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
+      const int top_k, vector<pair<Dtype, int> >* score_index_vec) {
+  // Generate index score pairs.
+  for (int i = 0; i < num; ++i) {
+    if (scores[i] > threshold) {
+      score_index_vec->push_back(std::make_pair(scores[i], i));
+    }
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::sort(score_index_vec->begin(), score_index_vec->end(),
+            SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+template
+void GetMaxScoreIndex(const float* scores, const int num, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+template
+void GetMaxScoreIndex(const double* scores, const int num,
+      const float threshold, const int top_k,
+      vector<pair<double, int> >* score_index_vec);
+
+template <typename Dtype>
+Dtype JaccardOverlap(const Dtype* bbox1, const Dtype* bbox2) {
+  if (bbox2[0] > bbox1[2] || bbox2[2] < bbox1[0] ||
+      bbox2[1] > bbox1[3] || bbox2[3] < bbox1[1]) {
+    return Dtype(0.);
+  } else {
+    const Dtype inter_xmin = std::max(bbox1[0], bbox2[0]);
+    const Dtype inter_ymin = std::max(bbox1[1], bbox2[1]);
+    const Dtype inter_xmax = std::min(bbox1[2], bbox2[2]);
+    const Dtype inter_ymax = std::min(bbox1[3], bbox2[3]);
+
+    const Dtype inter_width = inter_xmax - inter_xmin;
+    const Dtype inter_height = inter_ymax - inter_ymin;
+    const Dtype inter_size = inter_width * inter_height;
+
+    const Dtype bbox1_size = BBoxSize(bbox1);
+    const Dtype bbox2_size = BBoxSize(bbox2);
+
+    return inter_size / (bbox1_size + bbox2_size - inter_size);
+  }
+}
+
+template float JaccardOverlap(const float* bbox1, const float* bbox2);
+template double JaccardOverlap(const double* bbox1, const double* bbox2);
+
+template <typename Dtype>
+Dtype BBoxSize(const Dtype* bbox, const bool normalized) {
+  if (bbox[2] < bbox[0] || bbox[3] < bbox[1]) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return Dtype(0.);
+  } else {
+    const Dtype width = bbox[2] - bbox[0];
+    const Dtype height = bbox[3] - bbox[1];
+    if (normalized) {
+      return width * height;
+    } else {
+      // If bbox is not within range [0, 1].
+      return (width + 1) * (height + 1);
+    }
+  }
+}
+
+template float BBoxSize(const float* bbox, const bool normalized);
+template double BBoxSize(const double* bbox, const bool normalized);
+
+
+} // namespace caffe2

--- a/caffe2/utils/bbox_util.cu
+++ b/caffe2/utils/bbox_util.cu
@@ -1,0 +1,10 @@
+#include <map>
+#include <vector>
+
+#include "caffe2/utils/bbox_util.h"
+#include "caffe2/core/context_gpu.h"
+
+namespace caffe2 {
+
+
+} // namespace caffe2

--- a/caffe2/utils/bbox_util.h
+++ b/caffe2/utils/bbox_util.h
@@ -1,0 +1,97 @@
+#ifndef CAFFE2_UTILS_BBOX_UTIL_H_
+#define CAFFE2_UTILS_BBOX_UTIL_H_
+
+#include <vector>
+#include <stdint.h>
+#include <cmath>  // for std::fabs and std::signbit
+#include <map>
+#include <string>
+#include <utility>
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe2/core/common.h"
+#include "caffe2/core/logging.h"
+
+namespace caffe2 {
+using std::map;
+using std::pair;
+using caffe::NormalizedBBox;
+using caffe::PriorBoxParameter_CodeType;
+
+typedef PriorBoxParameter_CodeType CodeType;
+typedef map<int, vector<NormalizedBBox> > LabelBBox;
+
+
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_scores);
+
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+// Compute bbox size.
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized = true);
+
+// Decode all bboxes in a batch.
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_pred,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip, vector<LabelBBox>* all_decode_bboxes);
+// Decode a set of bboxes according to a set of prior bboxes.
+void DecodeBBoxes(const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const bool clip_bbox, const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes);
+// Decode a bbox according to a prior bbox.
+void DecodeBBox(const NormalizedBBox& prior_bbox,
+    const vector<float>& prior_variance, const CodeType code_type,
+    const bool variance_encoded_in_target, const bool clip_bbox,
+    const NormalizedBBox& bbox, NormalizedBBox* decode_bbox);
+// Clip the NormalizedBBox such that the range for each corner is [0, 1].
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox);
+
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices);
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2);
+// Compute the jaccard (intersection over union IoU) overlap between two bboxes.
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized = true);
+// Compute the intersection between two bboxes.
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox);
+
+template <typename Dtype>
+void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
+      const float score_threshold, const float nms_threshold,
+      const float eta, const int top_k, vector<int>* indices);
+
+template <typename Dtype>
+void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
+      const int top_k, vector<pair<Dtype, int> >* score_index_vec);
+
+template <typename Dtype>
+Dtype JaccardOverlap(const Dtype* bbox1, const Dtype* bbox2);
+
+template <typename Dtype>
+Dtype BBoxSize(const Dtype* bbox, const bool normalized = true);
+
+} // namspace caffe2
+
+#endif


### PR DESCRIPTION
 details in issues #1215 and #509
-caffe2  building is ok on CPU only without CUDA and GLOO
-caffe_translator command produce a predict_net.pb, predict_net.pbtxt andinit_net.pb 
- loading of the results in AIcamera example for android is failing with error ;
 A/native: [F given_tensor_fill_op.h:27] Check failed: output->size() == values_.size() output size: 2359296 given size: 1066588
A/native: terminating.