### PR TITLE
cmake: handle CUDA 9.1 in GCC version check

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -326,13 +326,14 @@ endif()
 if(USE_CUDA)
   include(cmake/Cuda.cmake)
   if(HAVE_CUDA)
-    # CUDA 9.0 requires GCC version <= 6
-    if (CUDA_VERSION VERSION_EQUAL 9.0)
+    # CUDA 9.x requires GCC version <= 6
+    if ((CUDA_VERSION VERSION_EQUAL   9.0) OR
+        (CUDA_VERSION VERSION_GREATER 9.0  AND CUDA_VERSION VERSION_LESS 10.0))
       if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
           NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0 AND
           CUDA_HOST_COMPILER STREQUAL CMAKE_C_COMPILER)
         message(FATAL_ERROR
-          "CUDA 9.0 is not compatible with GCC version >= 7. "
+          "CUDA ${CUDA_VERSION} is not compatible with GCC version >= 7. "
           "Use the following option to use another version (for example): \n"
           "  -DCUDA_HOST_COMPILER=/usr/bin/gcc-6\n")
       endif()


### PR DESCRIPTION
GCC version check is currently being skipped when using the
newly released CUDA 9.1.

This will also handle other CUDA 9.x minor releases if any,
reducing our work if there are such releases like 9.2. This
assumes that the next major CUDA version will be 10.0,
needing adjustment only after such major version is
released.