### PR TITLE
doc: update installation.md for third_party packages

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,8 @@ Get latest source from GitHub.
     git clone --recursive https://github.com/caffe2/caffe2.git
     cd caffe2
 
+Note that you might need to uninstall existing Eigen and pybind11 packages due to compile-time dependencies when building from source. For this reason, Caffe2 uses git submodules to reference external packages in the third_party folder. These are downloaded with the --recursive option.
+
 #### MacOS X
 
     brew install openblas glog gtest automake protobuf leveled lmdb


### PR DESCRIPTION
PR Description
-----------------

This commit informs the developers why they have to use packages of third_party
folder instead of packages in their Linux distribution.

By default, Caffe2 find installed packages in the Linux distribution. If it
cannot be found, as a next step Caffe2 uses the version bundled in third_party folder.

**Changes proposed in this PR:**
1. Added difference between Linux distro packages and third_party packages

**Self assessment:**
Checked.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>

