### PR TITLE
Revert "Add doxygen and graphviz to Jenkins docker base."

### DIFF
--- a/docker/jenkins/common/install_base.sh
+++ b/docker/jenkins/common/install_base.sh
@@ -17,9 +17,7 @@ install_ubuntu() {
           ca-certificates \
           cmake \
           curl \
-          doxygen \
           git \
-          graphviz \
           libgoogle-glog-dev \
           libhiredis-dev \
           libiomp-dev \


### PR DESCRIPTION
This reverts commit 417f1bab18b1721db5edc7ac8abaf883c1f7d3ee.

No longer needed since we'll add this within the Jenkins job itself.

