### PR TITLE
remove "-s" compilation flag from clang when build for Android

### DIFF
--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -83,14 +83,24 @@ CMAKE_ARGS+=("-DANDROID_NATIVE_API_LEVEL=21")
 CMAKE_ARGS+=("-DANDROID_CPP_FEATURES=rtti exceptions")
 
 # Compiler flags
+CMAKE_ARGS+=($@)
+USE_GCC=true
 CMAKE_ARGS+=("-DCMAKE_C_FLAGS=")
-CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-s")
+for arg in ${CMAKE_ARGS[@]};do
+  if [ $arg == "-DANDROID_TOOLCHAIN=clang" ];then
+    USE_GCC=false
+  elif [ $arg == "-DANDROID_TOOLCHAIN=gcc" ];then
+    USE_GCC=true
+  fi
+done
+if $USE_GCC;then
+  CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-s")
+fi
 
 cmake "$CAFFE2_ROOT" \
     -DCMAKE_INSTALL_PREFIX=../install \
     -DCMAKE_BUILD_TYPE=Release \
-    "${CMAKE_ARGS[@]}" \
-    "$@"
+    "${CMAKE_ARGS[@]}"
 
 # Cross-platform parallel build
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Now we use **clang** to build Caffe2 for Android with arm64-v8a ABI, but clang doesn't support "-s" compilation flag. If we append this flag to clang, it will report a warning:

> clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]

This submit will check we use gcc or clang to build Caffe2 for Android.