### PR TITLE
Edited Image_Pre-Processing_Pipeline.ipynb, reoder -> reorder

### DIFF
--- a/caffe2/python/tutorials/Image_Pre-Processing_Pipeline.ipynb
+++ b/caffe2/python/tutorials/Image_Pre-Processing_Pipeline.ipynb
@@ -749,7 +749,7 @@
     "\n",
     "### Final Preprocessing and the Batch Term\n",
     "\n",
-    "In the last steps below we are going to switch the image's data order to BGR, stuff that into the Color column, then reoder the columns for GPU processing (HCW-->CHW) and then add a fourth dimension (N) to the image to track the number of images. In theory, you can just keep adding dimensions to your data, but this one is required for Caffe2 as it relays to Caffe how many images to expect in this batch. We set it to one (1) to indicate there's only one image going into Caffe in this batch. Note that in the final output when we check `img.shape` the order is quite different. We've added N for number of images, and changed the order like so: `N, C, H, W`"
+    "In the last steps below we are going to switch the image's data order to BGR, stuff that into the Color column, then reorder the columns for GPU processing (HCW-->CHW) and then add a fourth dimension (N) to the image to track the number of images. In theory, you can just keep adding dimensions to your data, but this one is required for Caffe2 as it relays to Caffe how many images to expect in this batch. We set it to one (1) to indicate there's only one image going into Caffe in this batch. Note that in the final output when we check `img.shape` the order is quite different. We've added N for number of images, and changed the order like so: `N, C, H, W`"
    ]
   },
   {

--- a/caffe2/python/tutorials/py_gen/Image_Pre-Processing_Pipeline.py
+++ b/caffe2/python/tutorials/py_gen/Image_Pre-Processing_Pipeline.py
@@ -398,7 +398,7 @@ pyplot.title('224x224')
 # 
 # ### Final Preprocessing and the Batch Term
 # 
-# In the last steps below we are going to switch the image's data order to BGR, stuff that into the Color column, then reoder the columns for GPU processing (HCW-->CHW) and then add a fourth dimension (N) to the image to track the number of images. In theory, you can just keep adding dimensions to your data, but this one is required for Caffe2 as it relays to Caffe how many images to expect in this batch. We set it to one (1) to indicate there's only one image going into Caffe in this batch. Note that in the final output when we check `img.shape` the order is quite different. We've added N for number of images, and changed the order like so: `N, C, H, W`
+# In the last steps below we are going to switch the image's data order to BGR, stuff that into the Color column, then reorder the columns for GPU processing (HCW-->CHW) and then add a fourth dimension (N) to the image to track the number of images. In theory, you can just keep adding dimensions to your data, but this one is required for Caffe2 as it relays to Caffe how many images to expect in this batch. We set it to one (1) to indicate there's only one image going into Caffe in this batch. Note that in the final output when we check `img.shape` the order is quite different. We've added N for number of images, and changed the order like so: `N, C, H, W`
 
 # In[12]:
 


### PR DESCRIPTION
**Fixed typo**
I fixed typo on `caffe2/python/tutorials/Image_Pre-Processing_Pipeline.ipynb`.

> reoder -> reorder  

Please check below code.